### PR TITLE
Add convertUTCToLocalDateTime and convertLocalToUTCDateTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,34 @@ date.getHours(); // -> 14
 date.getMinutes(); // -> 5
 ```
 
+## Date/Time Conversion based on user timezone
+
+These can be used to convert the date/time to the user's timezone (based on `data-timezone` attribute) and back to UTC prior to using date/time formatting.
+
+To convert a UTC date to local timezone and get a `Date` with the year/month/day/hours/minutes/seconds corresponding to the `data-timezone` attribute:
+```javascript
+import {convertUTCToLocalDateTime} from '@brightspace-ui/intl/lib/dateTime.js';
+
+const localDateTime = convertUTCToLocalDateTime(
+	new Date(Date.UTC(2015, 8, 23, 14, 5))
+); // -> new Date(2015, 8, 23, 10, 5) in America/Toronto; new Date(2015, 8, 23, 4, 5) in Pacific/Rarotonga
+```
+
+Notes:
+- The result will be different depending on if `Date` vs. `Date.UTC` is used as input, since `Date` will be adjusted for the timezone offset of the location of the user.
+	- For example, with `data-timezone` set to `America/Toronto` and a user located within that timezone:
+		- `convertUTCToLocalDateTime(new Date(2015, 7, 23, 14, 5))` result will be `Date(2015, 7, 23, 14, 5, 0)`
+		- `convertUTCToLocalDateTime(new Date(Date.UTC(2015, 7, 23, 14, 5)))` result will be `Date(2015, 7, 23, 10, 5, 0)` (Toronto has a -4 offset in August)
+
+To convert a `Date` representative of the local timezone (from `data-timezone` attribute) into a UTC `Date`:
+```javascript
+import {convertLocalToUTCDateTime} from '@brightspace-ui/intl/lib/dateTime.js';
+
+const UTCDateTime = convertLocalToUTCDateTime(
+	new Date(2015, 8, 23, 14, 5)
+); // -> UTC Date(2015, 8, 23, 18, 5) in America/Toronto; UTC Date(2015, 8, 24, 0, 5) in Pacific/Rarotonga
+```
+
 ## File Size Formatting
 
 Use `formatFileSize` to format a file size appropriately for the user's locale.

--- a/README.md
+++ b/README.md
@@ -162,30 +162,40 @@ date.getMinutes(); // -> 5
 
 ## Date/Time Conversion based on user timezone
 
-These can be used to convert the date/time to the user's timezone (based on `data-timezone` attribute) and back to UTC prior to using date/time formatting.
+**These are a work in progress and are not ready for usage yet**
 
-To convert a UTC date to local timezone and get a `Date` with the year/month/day/hours/minutes/seconds corresponding to the `data-timezone` attribute:
+To convert an object containing a UTC date to an object containing a local date corresponding to the `data-timezone` attribute:
 ```javascript
 import {convertUTCToLocalDateTime} from '@brightspace-ui/intl/lib/dateTime.js';
 
+const UTCDateTime =  {
+	month: 12,
+	date: 1,
+	year: 2015,
+	hours: 8,
+	minutes: 0,
+	seconds: 0
+};
 const localDateTime = convertUTCToLocalDateTime(
-	new Date(Date.UTC(2015, 8, 23, 14, 5))
-); // -> new Date(2015, 8, 23, 10, 5) in America/Toronto; new Date(2015, 8, 23, 4, 5) in Pacific/Rarotonga
+	UTCDateTime
+); // -> { month: 12, date: 1, year: 2015, hours: 3, minutes: 0, seconds: 0 } in America/Toronto
 ```
 
-Notes:
-- The result will be different depending on if `Date` vs. `Date.UTC` is used as input, since `Date` will be adjusted for the timezone offset of the location of the user.
-	- For example, with `data-timezone` set to `America/Toronto` and a user located within that timezone:
-		- `convertUTCToLocalDateTime(new Date(2015, 7, 23, 14, 5))` result will be `Date(2015, 7, 23, 14, 5, 0)`
-		- `convertUTCToLocalDateTime(new Date(Date.UTC(2015, 7, 23, 14, 5)))` result will be `Date(2015, 7, 23, 10, 5, 0)` (Toronto has a -4 offset in August)
-
-To convert a `Date` representative of the local timezone (from `data-timezone` attribute) into a UTC `Date`:
+To convert an object containing a local date corresponding to the `data-timezone` attribute to an object containing a UTC date:
 ```javascript
 import {convertLocalToUTCDateTime} from '@brightspace-ui/intl/lib/dateTime.js';
 
+const localDateTime =  {
+	month: 12,
+	date: 1,
+	year: 2015,
+	hours: 8,
+	minutes: 0,
+	seconds: 0
+};
 const UTCDateTime = convertLocalToUTCDateTime(
-	new Date(2015, 8, 23, 14, 5)
-); // -> UTC Date(2015, 8, 23, 18, 5) in America/Toronto; UTC Date(2015, 8, 24, 0, 5) in Pacific/Rarotonga
+	localDateTime
+); // -> { month: 12, date: 1, year: 2015, hours: 13, minutes: 0, seconds: 0 } in America/Toronto
 ```
 
 ## File Size Formatting

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -197,8 +197,10 @@ export function convertLocalToUTCDateTime(date) {
 		return date;
 	}
 	const dateDate = new Date(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds);
+	console.log('date here ' + dateDate);
 	const timezone = formatDateString(dateDate).split(' ')[2];
 	const dateStringInTimezone = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${timezone}`;
+	console.log('string ' + dateStringInTimezone);
 	const utcCorrectedDate = new Date(Date.parse(dateStringInTimezone));
 
 	return {

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -14,7 +14,8 @@ function buildDayPeriodRe(part) {
 	return new RegExp(re, 'i');
 }
 
-function convertDateToTimezone(date, timezone) {
+function formatDateString(date) {
+	const timezone = getDocumentLocaleSettings().timezone.identifier;
 	const options = {
 		year: 'numeric',
 		month: '2-digit',
@@ -22,30 +23,14 @@ function convertDateToTimezone(date, timezone) {
 		hour: '2-digit',
 		minute: '2-digit',
 		second: '2-digit',
-		hour12: false, // use 24-hour time format
+		hour12: false,
 	};
 	if (timezone) {
 		options.timeZone = timezone;
+		options.timeZoneName = 'short';
 	}
-
 	const formatter = new Intl.DateTimeFormat('en-US', options);
-	let formattedDateTime = formatter.format(date);
-
-	if (formattedDateTime.indexOf(',') > -1) {
-		formattedDateTime = formattedDateTime.replace(/,/g, '');
-	}
-
-	const splitDateTime = formattedDateTime.split(' ');
-	const splitDate = splitDateTime[0].split('/'); // 01/31/2019
-	const splitTime = splitDateTime[1].split(':'); // 13:10:30
-
-	return new Date(splitDate[2],
-		splitDate[0] - 1,
-		splitDate[1],
-		splitTime[0],
-		splitTime[1],
-		splitTime[2]
-	);
+	return formatter.format(date);
 }
 
 function getParts() {
@@ -187,34 +172,42 @@ function processPattern(pattern, replacements) {
 }
 
 export function convertUTCToLocalDateTime(date) {
-	const timezone = getDocumentLocaleSettings().timezone.identifier;
-	return convertDateToTimezone(date, timezone);
+	if (!getDocumentLocaleSettings().timezone.identifier) {
+		return date;
+	}
+	const utcDate = new Date(Date.UTC(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds));
+	const formattedDateTime = formatDateString(utcDate);
+	const splitDateTime = formattedDateTime.split(' ');
+	const splitDate = splitDateTime[0].split('/');
+	const splitTime = splitDateTime[1].split(':');
+
+	return {
+		month: parseInt(splitDate[0]),
+		date: parseInt(splitDate[1]),
+		year: parseInt(splitDate[2]),
+		hours: parseInt(splitTime[0]),
+		minutes: parseInt(splitTime[1]),
+		seconds: parseInt(splitTime[2])
+	};
 }
 
 export function convertLocalToUTCDateTime(date) {
-	// calculate timezone offset each time in case different because of daylight savings
-	// get date/time in timezone, get date/time in UTC, calculate difference
-	let dateInTimezone = convertDateToTimezone(date, getDocumentLocaleSettings().timezone.identifier);
-	const timeChangeOffset = date.getTimezoneOffset() - dateInTimezone.getTimezoneOffset(); // handle daylight savings
-	let timeChangeAdjustedDate = date;
-	if (timeChangeOffset !== 0) {
-		timeChangeAdjustedDate = new Date(date.getTime() - timeChangeOffset * 60000);
-		dateInTimezone = convertDateToTimezone(timeChangeAdjustedDate, getDocumentLocaleSettings().timezone.identifier);
+	if (!getDocumentLocaleSettings().timezone.identifier) {
+		return date;
 	}
-	const dateInUTC = convertDateToTimezone(timeChangeAdjustedDate, 'UTC');
-	const diff = dateInTimezone - dateInUTC;
+	const dateDate = new Date(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds);
+	const timezone = formatDateString(dateDate).split(' ')[2];
+	const dateStringInTimezone = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${timezone}`;
+	const utcCorrectedDate = new Date(Date.parse(dateStringInTimezone));
 
-	// subtract calculated offset from date and create new UTC date based on calculated values
-	const dateWithOffset = new Date(date.getTime() - diff);
-	return new Date(
-		Date.UTC(
-			dateWithOffset.getFullYear(),
-			dateWithOffset.getMonth(),
-			dateWithOffset.getDate(),
-			dateWithOffset.getHours(),
-			dateWithOffset.getMinutes()
-		)
-	);
+	return {
+		month: utcCorrectedDate.getUTCMonth() + 1,
+		date: utcCorrectedDate.getUTCDate(),
+		year: utcCorrectedDate.getUTCFullYear(),
+		hours: utcCorrectedDate.getUTCHours(),
+		minutes: utcCorrectedDate.getUTCMinutes(),
+		seconds: utcCorrectedDate.getUTCSeconds()
+	};
 }
 
 export function getDateTimeDescriptor() {

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -196,11 +196,15 @@ export function convertLocalToUTCDateTime(date) {
 	if (!getDocumentLocaleSettings().timezone.identifier) {
 		return date;
 	}
+
 	const dateDate = new Date(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds);
-	console.log('date here ' + dateDate);
 	const timezone = formatDateString(dateDate).split(' ')[2];
-	const dateStringInTimezone = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${timezone}`;
-	console.log('string ' + dateStringInTimezone);
+	const dateString = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${timezone}`;
+	const parsedDateString = new Date(Date.parse(dateString));
+
+	// run again in case of DST (e.g., if timezone is CST for dateDate but local time is after CST is over, timezone is incorrect)
+	const utcCorrectedTimezone = formatDateString(parsedDateString).split(' ')[2];
+	const dateStringInTimezone = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${utcCorrectedTimezone}`;
 	const utcCorrectedDate = new Date(Date.parse(dateStringInTimezone));
 
 	return {

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -14,6 +14,40 @@ function buildDayPeriodRe(part) {
 	return new RegExp(re, 'i');
 }
 
+function convertDateToTimezone(date, timezone) {
+	const options = {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hour12: false, // use 24-hour time format
+	};
+	if (timezone) {
+		options.timeZone = timezone;
+	}
+
+	const formatter = new Intl.DateTimeFormat('en-US', options);
+	let formattedDateTime = formatter.format(date);
+
+	if (formattedDateTime.indexOf(',') > -1) {
+		formattedDateTime = formattedDateTime.replace(/,/g, '');
+	}
+
+	const splitDateTime = formattedDateTime.split(' ');
+	const splitDate = splitDateTime[0].split('/'); // 01/31/2019
+	const splitTime = splitDateTime[1].split(':'); // 13:10:30
+
+	return new Date(splitDate[2],
+		splitDate[0] - 1,
+		splitDate[1],
+		splitTime[0],
+		splitTime[1],
+		splitTime[2]
+	);
+}
+
 function getParts() {
 
 	const descriptor = getDateTimeDescriptor();
@@ -150,6 +184,26 @@ function processPattern(pattern, replacements) {
 
 	return value;
 
+}
+
+export function convertUTCToLocalDateTime(date) {
+	const timezone = getDocumentLocaleSettings().timezone.identifier;
+	return convertDateToTimezone(date, timezone);
+}
+
+export function convertLocalToUTCDateTime(date) {
+	// calculate offset each time in case different because of daylight savings
+	let dateInTimezone = convertDateToTimezone(date, getDocumentLocaleSettings().timezone.identifier);
+	const timeChangeOffset = date.getTimezoneOffset() - dateInTimezone.getTimezoneOffset(); // handle daylight savings
+	let timeChangeAdjustedDate = date;
+	if (timeChangeOffset !== 0) {
+		timeChangeAdjustedDate = new Date(date.getTime() - timeChangeOffset * 60000);
+		dateInTimezone = convertDateToTimezone(timeChangeAdjustedDate, getDocumentLocaleSettings().timezone.identifier);
+	}
+
+	const dateInUTC = convertDateToTimezone(timeChangeAdjustedDate, 'UTC');
+	const diff = dateInTimezone - dateInUTC;
+	return new Date(date.getTime() - diff);
 }
 
 export function getDateTimeDescriptor() {

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -192,7 +192,8 @@ export function convertUTCToLocalDateTime(date) {
 }
 
 export function convertLocalToUTCDateTime(date) {
-	// calculate offset each time in case different because of daylight savings
+	// calculate timezone offset each time in case different because of daylight savings
+	// get date/time in timezone, get date/time in UTC, calculate difference
 	let dateInTimezone = convertDateToTimezone(date, getDocumentLocaleSettings().timezone.identifier);
 	const timeChangeOffset = date.getTimezoneOffset() - dateInTimezone.getTimezoneOffset(); // handle daylight savings
 	let timeChangeAdjustedDate = date;
@@ -200,10 +201,20 @@ export function convertLocalToUTCDateTime(date) {
 		timeChangeAdjustedDate = new Date(date.getTime() - timeChangeOffset * 60000);
 		dateInTimezone = convertDateToTimezone(timeChangeAdjustedDate, getDocumentLocaleSettings().timezone.identifier);
 	}
-
 	const dateInUTC = convertDateToTimezone(timeChangeAdjustedDate, 'UTC');
 	const diff = dateInTimezone - dateInUTC;
-	return new Date(date.getTime() - diff);
+
+	// subtract calculated offset from date and create new UTC date based on calculated values
+	const dateWithOffset = new Date(date.getTime() - diff);
+	return new Date(
+		Date.UTC(
+			dateWithOffset.getFullYear(),
+			dateWithOffset.getMonth(),
+			dateWithOffset.getDate(),
+			dateWithOffset.getHours(),
+			dateWithOffset.getMinutes()
+		)
+	);
 }
 
 export function getDateTimeDescriptor() {

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -177,17 +177,18 @@ export function convertUTCToLocalDateTime(date) {
 	}
 	const utcDate = new Date(Date.UTC(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds));
 	const formattedDateTime = formatDateString(utcDate);
-	const splitDateTime = formattedDateTime.split(' ');
-	const splitDate = splitDateTime[0].split('/');
-	const splitTime = splitDateTime[1].split(':');
-
+	const re = /([0-9]{1,2})\/([0-9]{1,2})\/([0-9]{4})( |, )([0-9]{1,2}):([0-9]{2}):([0-9]{2})/;
+	const match = formattedDateTime.match(re);
+	if (!match || match.length !== 8) {
+		return date;
+	}
 	return {
-		month: parseInt(splitDate[0]),
-		date: parseInt(splitDate[1]),
-		year: parseInt(splitDate[2]),
-		hours: parseInt(splitTime[0]),
-		minutes: parseInt(splitTime[1]),
-		seconds: parseInt(splitTime[2])
+		month: parseInt(match[1]),
+		date: parseInt(match[2]),
+		year: parseInt(match[3]),
+		hours: parseInt(match[5]),
+		minutes: parseInt(match[6]),
+		seconds: parseInt(match[7])
 	};
 }
 

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -158,14 +158,14 @@ describe('dateTime', () => {
 
 			describe('Daylight Savings', () => {
 				[
-					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, day: 8, hours: 3, minutes: '01'},
+					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, day: 8, hours: 4, minutes: '00'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 3, day: 8, hours: 1, minutes: '59'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 11, day: 1, hours: 1, minutes: '59'},
-					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, day: 1, hours: 2, minutes: '01'},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, day: 8, hours: 3, minutes: '01'},
+					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, day: 1, hours: 3, minutes: '00'},
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, day: 8, hours: 4, minutes: '00'},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 3, day: 8, hours: 1, minutes: '59'},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 11, day: 1, hours: 1, minutes: '59'},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, day: 1, hours: 2, minutes: '01'}
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, day: 1, hours: 3, minutes: '00'}
 				].forEach((test) => {
 					it(`${test.timezone}: should have expected GMT offset of ${test.expectedGMTOffset} hours on ${test.month}/${test.day} at ${test.hours}:${test.minutes} AM `, () => {
 						const daylightSavingsDate = new Date(2015, test.month - 1, test.day, test.hours, test.minutes);

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -176,14 +176,14 @@ describe('dateTime', () => {
 
 			describe('Daylight Savings', () => {
 				[
-					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, date: 8, hours: 6, minutes: 0},
+					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, date: 8, hours: 3, minutes: 0},
 					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 3, date: 8, hours: 1, minutes: 59},
 					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 11, date: 1, hours: 1, minutes: 59},
-					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, date: 1, hours: 6, minutes: 0},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, date: 8, hours: 6, minutes: 0},
+					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, date: 1, hours: 3, minutes: 0},
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, date: 8, hours: 3, minutes: 0},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 3, date: 8, hours: 1, minutes: 59},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 11, date: 1, hours: 1, minutes: 59},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, date: 1, hours: 6, minutes: 0}
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, date: 1, hours: 3, minutes: 0}
 				].forEach((test) => {
 					it(`${test.timezone}: should have expected GMT offset of ${test.expectedGMTOffset} hours on ${test.month}/${test.date} at ${test.hours}:${test.minutes} AM `, () => {
 						const dateTime = {

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -176,14 +176,14 @@ describe('dateTime', () => {
 
 			describe('Daylight Savings', () => {
 				[
-					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, date: 8, hours: 3, minutes: 0},
+					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, date: 8, hours: 6, minutes: 0},
 					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 3, date: 8, hours: 1, minutes: 59},
 					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 11, date: 1, hours: 1, minutes: 59},
-					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, date: 1, hours: 3, minutes: 0},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, date: 8, hours: 4, minutes: 0},
+					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, date: 1, hours: 6, minutes: 0},
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, date: 8, hours: 6, minutes: 0},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 3, date: 8, hours: 1, minutes: 59},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 11, date: 1, hours: 1, minutes: 59},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, date: 1, hours: 3, minutes: 0}
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, date: 1, hours: 6, minutes: 0}
 				].forEach((test) => {
 					it(`${test.timezone}: should have expected GMT offset of ${test.expectedGMTOffset} hours on ${test.month}/${test.date} at ${test.hours}:${test.minutes} AM `, () => {
 						const dateTime = {

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -158,14 +158,14 @@ describe('dateTime', () => {
 
 			describe('Daylight Savings', () => {
 				[
-					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, day: 8, hours: 3, minutes: '00'},
+					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, day: 8, hours: 3, minutes: '01'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 3, day: 8, hours: 1, minutes: '59'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 11, day: 1, hours: 1, minutes: '59'},
-					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, day: 1, hours: 2, minutes: '00'},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, day: 8, hours: 3, minutes: '00'},
+					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, day: 1, hours: 2, minutes: '01'},
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 3, day: 8, hours: 3, minutes: '01'},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 3, day: 8, hours: 1, minutes: '59'},
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 5, month: 11, day: 1, hours: 1, minutes: '59'},
-					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, day: 1, hours: 2, minutes: '00'}
+					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, day: 1, hours: 2, minutes: '01'}
 				].forEach((test) => {
 					it(`${test.timezone}: should have expected GMT offset of ${test.expectedGMTOffset} hours on ${test.month}/${test.day} at ${test.hours}:${test.minutes} AM `, () => {
 						const daylightSavingsDate = new Date(2015, test.month - 1, test.day, test.hours, test.minutes);

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -158,7 +158,7 @@ describe('dateTime', () => {
 
 			describe('Daylight Savings', () => {
 				[
-					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, day: 8, hours: 4, minutes: '00'},
+					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 3, day: 8, hours: 10, minutes: '00'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 3, day: 8, hours: 1, minutes: '59'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 4, month: 11, day: 1, hours: 1, minutes: '59'},
 					{timezone: 'America/Toronto', expectedGMTOffset: 5, month: 11, day: 1, hours: 3, minutes: '00'},
@@ -171,9 +171,12 @@ describe('dateTime', () => {
 						const daylightSavingsDate = new Date(2015, test.month - 1, test.day, test.hours, test.minutes);
 						documentLocaleSettings.timezone.identifier = test.timezone;
 						const result = convertLocalToUTCDateTime(daylightSavingsDate);
-						const expectedHour = test.hours + test.expectedGMTOffset;
+						let expectedHour = test.hours + test.expectedGMTOffset;
 						const expectedMonth = test.month === 3 ? 'Mar' : 'Nov';
-						expect(result.toUTCString()).to.contain(`0${test.day} ${expectedMonth} 2015 0${expectedHour}:${test.minutes}:00`);
+						if (expectedHour < 10) {
+							expectedHour = `0${expectedHour}`;
+						}
+						expect(result.toUTCString()).to.contain(`0${test.day} ${expectedMonth} 2015 ${expectedHour}:${test.minutes}:00`);
 					});
 				});
 			});

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -19,7 +19,11 @@ describe('dateTime', () => {
 
 	describe('converting date/time', () => {
 
-		function getExpectedResult(date, minutes, hours, offset) {
+		function getExpectedResult(input, offset) {
+			let hours = input.hours;
+			let minutes = input.minutes;
+			let date = input.date;
+
 			// calculate what expected hours and minutes should be based on offset
 			const offsetHours = Math.floor(Math.abs(offset));
 			if (offset < 0) {
@@ -46,38 +50,35 @@ describe('dateTime', () => {
 			}
 
 			return {
+				month: input.month,
 				date: date,
+				year: input.year,
 				hours: hours,
-				minutes: minutes
+				minutes: minutes,
+				seconds: input.seconds
 			};
 		}
 
 		describe('convertUTCToLocalDateTime', () => {
-			it('should return original date if timezone identifier is blank', () => {
-				const UTCDateTime = {
-					month: 8,
-					date: 25,
-					year: 2015,
-					hours: 12,
-					minutes: 28,
-					seconds: 0
-				};
+			const hours = 12;
+			const minutes = 28;
+			const date = 25;
+			const UTCDateTime = {
+				month: 8,
+				date: date,
+				year: 2015,
+				hours: hours,
+				minutes: minutes,
+				seconds: 0
+			};
 
+			it('should return original date if timezone identifier is blank', () => {
 				documentLocaleSettings.timezone.identifier = '';
 				const result = convertUTCToLocalDateTime(UTCDateTime);
 				expect(result).to.deep.equal(UTCDateTime);
 			});
 
 			it('should throw if timezone identifier is invalid', () => {
-				const UTCDateTime = {
-					month: 8,
-					date: 25,
-					year: 2015,
-					hours: 12,
-					minutes: 28,
-					seconds: 0
-				};
-
 				documentLocaleSettings.timezone.identifier = 'FAKE';
 				expect(() => {
 					convertUTCToLocalDateTime(UTCDateTime);
@@ -94,30 +95,10 @@ describe('dateTime', () => {
 				{timezone: 'Pacific/Apia', expectedGMTOffset: 13}
 			].forEach((test) => {
 				it(`should have expected GMT offset of ${test.expectedGMTOffset} for timezone ${test.timezone}`, () => {
-					const hours = 12;
-					const minutes = 28;
-					const date = 25;
-					const UTCDateTime = {
-						month: 8,
-						date: date,
-						year: 2015,
-						hours: hours,
-						minutes: minutes,
-						seconds: 0
-					};
-
 					documentLocaleSettings.timezone.identifier = test.timezone;
 					const result = convertUTCToLocalDateTime(UTCDateTime);
-					const expectedResult = getExpectedResult(date, minutes, hours, test.expectedGMTOffset);
-					const expected = {
-						month: 8,
-						date: expectedResult.date,
-						year: 2015,
-						hours: expectedResult.hours,
-						minutes: expectedResult.minutes,
-						seconds: 0
-					};
-					expect(result).to.deep.equal(expected);
+					const expectedResult = getExpectedResult(UTCDateTime, test.expectedGMTOffset);
+					expect(result).to.deep.equal(expectedResult);
 				});
 			});
 
@@ -133,7 +114,7 @@ describe('dateTime', () => {
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, date: 1, hours: 8, minutes: 0}
 				].forEach((test) => {
 					it(`${test.timezone}: should have expected GMT offset of ${test.expectedGMTOffset} hours on ${test.month}/${test.date} at ${test.hours}:${test.minutes} AM UTC `, () => {
-						const UTCDateTime = {
+						const dateTime = {
 							month: test.month,
 							date: test.date,
 							year: 2015,
@@ -142,88 +123,54 @@ describe('dateTime', () => {
 							seconds: 0
 						};
 						documentLocaleSettings.timezone.identifier = test.timezone;
-						const result = convertUTCToLocalDateTime(UTCDateTime);
-						const expectedHour = test.hours - test.expectedGMTOffset;
-						const expected = {
-							month: test.month,
-							date: test.date,
-							year: 2015,
-							hours: expectedHour,
-							minutes: test.minutes,
-							seconds: 0
-						};
-						expect(result).to.deep.equal(expected);
+						const result = convertUTCToLocalDateTime(dateTime);
+						const expectedResult = getExpectedResult(dateTime, -1 * test.expectedGMTOffset);
+						expect(result).to.deep.equal(expectedResult);
 					});
 				});
 			});
 		});
 
 		describe('convertLocalToUTCDateTime', () => {
-			it('should return original date if timezone identifier is blank', () => {
-				const UTCDateTime = {
-					month: 8,
-					date: 25,
-					year: 2015,
-					hours: 12,
-					minutes: 28,
-					seconds: 0
-				};
+			const hours = 8;
+			const minutes = 52;
+			const date = 10;
+			const localDateTime = {
+				month: 2,
+				date: date,
+				year: 2015,
+				hours: hours,
+				minutes: minutes,
+				seconds: 0
+			};
 
+			it('should return original date if timezone identifier is blank', () => {
 				documentLocaleSettings.timezone.identifier = '';
-				const result = convertLocalToUTCDateTime(UTCDateTime);
-				expect(result).to.deep.equal(UTCDateTime);
+				const result = convertLocalToUTCDateTime(localDateTime);
+				expect(result).to.deep.equal(localDateTime);
 			});
 
 			it('should throw if timezone identifier is invalid', () => {
-				const UTCDateTime = {
-					month: 8,
-					date: 25,
-					year: 2015,
-					hours: 12,
-					minutes: 28,
-					seconds: 0
-				};
-
 				documentLocaleSettings.timezone.identifier = 'FAKE';
 				expect(() => {
-					convertLocalToUTCDateTime(UTCDateTime);
+					convertLocalToUTCDateTime(localDateTime);
 				}).to.throw();
 			});
 
 			[
 				{timezone: 'Pacific/Rarotonga', expectedGMTOffset: -10},
-				{timezone: 'America/Santa_Isabel', expectedGMTOffset: -7},
-				{timezone: 'America/Toronto', expectedGMTOffset: -4},
+				{timezone: 'America/Santa_Isabel', expectedGMTOffset: -8},
+				{timezone: 'America/Toronto', expectedGMTOffset: -5},
 				{timezone: 'Atlantic/Reykjavik', expectedGMTOffset: 0},
 				{timezone: 'Australia/Eucla', expectedGMTOffset: 8.75},
 				{timezone: 'Australia/Darwin', expectedGMTOffset: 9.5},
-				{timezone: 'Pacific/Apia', expectedGMTOffset: 13}
+				{timezone: 'Pacific/Apia', expectedGMTOffset: 14}
 			].forEach((test) => {
 				it(`should have expected GMT offset of ${test.expectedGMTOffset} for timezone ${test.timezone}`, () => {
-					const hours = 8;
-					const minutes = 52;
-					const date = 10;
-					const localDateTime = {
-						month: 4,
-						date: date,
-						year: 2015,
-						hours: hours,
-						minutes: minutes,
-						seconds: 0
-					};
-
 					documentLocaleSettings.timezone.identifier = test.timezone;
-					const expectedResult = getExpectedResult(date, minutes, hours, -1 * test.expectedGMTOffset);
 					const result = convertLocalToUTCDateTime(localDateTime);
-					const expected = {
-						month: 4,
-						date: expectedResult.date,
-						year: 2015,
-						hours: expectedResult.hours,
-						minutes: expectedResult.minutes,
-						seconds: 0
-					};
-					expect(result).to.deep.equal(expected);
+					const expectedResult = getExpectedResult(localDateTime, -1 * test.expectedGMTOffset);
+					expect(result).to.deep.equal(expectedResult);
 				});
 			});
 
@@ -239,7 +186,7 @@ describe('dateTime', () => {
 					{timezone: 'America/Winnipeg', expectedGMTOffset: 6, month: 11, date: 1, hours: 3, minutes: 0}
 				].forEach((test) => {
 					it(`${test.timezone}: should have expected GMT offset of ${test.expectedGMTOffset} hours on ${test.month}/${test.date} at ${test.hours}:${test.minutes} AM `, () => {
-						const localDateTime = {
+						const dateTime = {
 							month: test.month,
 							date: test.date,
 							year: 2015,
@@ -248,18 +195,9 @@ describe('dateTime', () => {
 							seconds: 0
 						};
 						documentLocaleSettings.timezone.identifier = test.timezone;
-						const result = convertLocalToUTCDateTime(localDateTime);
-						const expectedHours = test.hours + test.expectedGMTOffset;
-
-						const expected = {
-							month: test.month,
-							date: test.date,
-							year: 2015,
-							hours: expectedHours,
-							minutes: test.minutes,
-							seconds: 0
-						};
-						expect(result).to.deep.equal(expected);
+						const result = convertLocalToUTCDateTime(dateTime);
+						const expectedResult = getExpectedResult(dateTime, test.expectedGMTOffset);
+						expect(result).to.deep.equal(expectedResult);
 					});
 				});
 			});


### PR DESCRIPTION
~~`convertUTCToLocalDateTime` takes a UTC date (e.g., `new Date(Date.UTC(2015, ... )`) and returns a `Date` with year/month/day/hour/minute/second corresponding to the `data-timezone` identifier (e.g., `America/Toronto`). This can then be used by `formatDate` etc~~

~~`convertLocalToUTCDateTime` takes the local date and returns what that date is in UTC.
Currently some of the daylight savings tests for this are failing when run with Travis so I'm looking into that.~~

After some discussion it was decided to do the following:
`convertUTCToLocalDateTime` takes an object representing a UTC date/time and returns an object representing a date/time in the local timezone corresponding to the `data-timezone` identifier (e.g., `America/Toronto`)

`convertLocalToUTCDateTime` take an object representing a local date/time and returns an object representing that date/time in UTC based on the local timezone corresponding to the `data-timezone` identifier

The README has these marked as do not use yet since it's possible they will change (e.g., perhaps they will support `Date`, etc)


