### PR TITLE
Adding fuzzy formatters. Bump to 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,52 @@ Options:
   - **full**: includes timezone. e.g. `'1:25 PM EST'`
   - **medium** or **short**: excludes timezone e.g. `'1:25 PM'`
 
+## Fuzzy Date/Time Formatting
+
+Dates and times can be "fuzzy" formatted in the user's locale using `formatFuzzyDate` and `formatFuzzyDateTime`. Here we define fuzzy formatting as automatically choosing a relative or absolute formatting based on the difference in time to another date called the `origin` (which is by default the current datetime).
+
+- Relative formatting is used within 3 days of the origin. The [Intl.RelativeTimeFormat][] web standard is used if available, otherwise the fuzzy functions default to absolute formatting. Some examples of relative formatting are:
+  * `2 seconds ago`
+  * `yesterday`
+  * `tomorrow`
+  * `in 3 days`
+- Absolute formatting is used beyond 3 days from the origin. Options are forwarded to `formatDate` and `formatDateTime` in this case. See [Date/Time Formatting](#datetime-formatting) for details.
+
+The `formatFuzzyDate` and `formatFuzzyDateTime` differ only in how they format absolutely. Relative formatting is the same for each.
+
+```javascript
+import {formatFuzzyDateTime} from '@brightspace-ui/intl/lib/fuzzyDateTime.js';
+
+const origin = new Date(2015, 8, 23, 14, 5, 30);
+
+formatFuzzyDateTime(
+	new Date(2015, 8, 23, 14, 5, 18),
+	{ origin } // omit for current datetime
+); // -> '12 seconds ago' in en
+```
+
+Since relatively formatted values become incorrect as time passes, an optional callback `onUpdate` can be provided to get notified when the value should be changed.
+
+```javascript
+formatFuzzyDate(
+	new Date(2015, 8, 23, 14, 5, 25),
+	{ origin, onUpdate }
+);
+// onUpdate() gets invoked with:
+// - '5 second ago'
+// - 'this minute'
+// - '1 minute ago'
+// - '2 minutes ago'
+// ...
+// - '3 days ago'
+// - '9/23/2015'
+```
+
+Options:
+- **absoluteFormat**: forwarded to `formatFuzzyDate` or `formatFuzzyDateTime` as `format` option.
+- **origin**: a reference `Date` used to determine the relative time. By default `new Date()` is used (i.e. the current date/time)
+- **onUpdate**: if provided, this callback will be invoked whenever the relative formatting needs to change
+
 ## Date Parsing
 
 To parse a date written in the user's locale, use `parseDate`:
@@ -217,3 +263,6 @@ Contributions are welcome, please submit a pull request!
 All version changes should obey [semantic versioning](https://semver.org/) rules.
 
 Include either `[increment major]`, `[increment minor]` or `[increment patch]` in your merge commit message to automatically increment the `package.json` version, create a tag and trigger a deployment to NPM.
+
+
+[Intl.RelativeTimeFormat]:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat

--- a/lib/fuzzyDateTime.js
+++ b/lib/fuzzyDateTime.js
@@ -1,0 +1,104 @@
+import { getLanguage } from './common.js';
+import { formatDateTime, formatDate } from './dateTime.js';
+
+const second = 1000;
+const minute = 60 * second;
+const hour = 60 * minute;
+const day = 24 * hour;
+const thirtySeconds = 30 * second;
+const halfHour = 30 * minute;
+const hourAndHalf = 90 * minute;
+const fortyFiveMinutes = 45 * minute;
+const threeAndAHalfDays = 84 * hour;
+const sixHours = 6 * hour;
+
+const defaultRtf = Intl && Intl.RelativeTimeFormat &&
+	new Intl.RelativeTimeFormat(getLanguage(), {
+		localeMatcher: 'best fit',
+		numeric: 'auto',
+		style: 'long'
+	});
+
+const midnightTime = dateTime =>
+	new Date(
+		dateTime.getFullYear(),
+		dateTime.getMonth(),
+		dateTime.getDate()
+	).getTime();
+
+const noonTime = dateTime =>
+	new Date(
+		dateTime.getFullYear(),
+		dateTime.getMonth(),
+		dateTime.getDate(),
+		12
+	).getTime();
+
+// Adapted from:
+// https://search.d2l.dev/xref/lms/lp/framework/web/D2L.LP.Web/UI/JavaScript/Globalization/Formatting/DateTime/DateTimeFormatter.js?r=438b5dc3#125
+//
+// but modified to work with:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat
+//
+const formatFuzzy = formatFunction => (inputDate, {
+	absoluteFormat = 'short',
+	origin = new Date(),
+	onUpdate = null,
+	rtf = defaultRtf
+} = {}) => {
+	const midnight = midnightTime(origin);
+	const noon = noonTime(origin);
+	const now = origin.getTime();
+
+	const sameDay = midnightTime(inputDate) === midnight;
+	const timespan = inputDate.getTime() - origin.getTime();
+	const timespanFromNoon = inputDate.getTime() - noon;
+	const timespanAbs = Math.abs(timespan);
+	const isPast = timespan < 0;
+
+	let text;
+	let timeout;
+	if (rtf && timespanAbs < thirtySeconds) {
+		text = rtf.format(Math.round(timespan / second), 'second');
+		timeout = isPast ?
+			thirtySeconds - timespanAbs :
+			thirtySeconds + timespanAbs;
+	} else if (rtf && timespanAbs < fortyFiveMinutes) {
+		text = rtf.format(Math.round(timespan / minute), 'minute');
+		timeout = minute;
+	} else if (rtf && (timespanAbs < sixHours || sameDay)) {
+		const minutes = (timespanAbs % hour);
+		text = rtf.format(Math.round(timespan / hour), 'hour');
+		timeout = (isPast ? hourAndHalf - minutes : halfHour + minutes) % hour ;
+	} else if (rtf && Math.abs(timespanFromNoon) < threeAndAHalfDays) {
+		text = rtf.format(Math.round(timespanFromNoon / day), 'day');
+		timeout = noon - now + (now < noon ? 0 : day);
+	} else {
+		text = formatFunction(inputDate, { format: absoluteFormat });
+		timeout = -1;
+	}
+
+	if (timeout > 0) {
+		timeout = Math.max(timeout, 1000);
+	}
+
+	if (onUpdate) {
+		const updateResult = onUpdate(text, { nextUpdateInMilliseconds: timeout });
+		const shouldCancel = updateResult === false;
+		if (!shouldCancel && timeout > 0) {
+			setTimeout(() => {
+				formatFuzzy(formatFunction)(inputDate, {
+					absoluteFormat,
+					onUpdate,
+					rtf
+				});
+			}, timeout);
+		}
+	}
+
+	return text;
+};
+
+export const millisecondsPer = { second, minute, hour, day };
+export const formatFuzzyDate = formatFuzzy(formatDate);
+export const formatFuzzyDateTime = formatFuzzy(formatDateTime);

--- a/test/fuzzyDateTime.js
+++ b/test/fuzzyDateTime.js
@@ -1,0 +1,205 @@
+import {
+	formatFuzzyDate,
+	formatFuzzyDateTime,
+	millisecondsPer
+} from '../lib/fuzzyDateTime.js';
+
+const { second, minute, hour, day } = millisecondsPer;
+
+var expect = chai.expect;
+
+const noon = new Date(2000, 1, 1, 12, 0, 0, 0);
+const ninePM = new Date(2000, 1, 1, 21, 0, 0, 0);
+const threeAM = new Date(2000, 1, 1, 3, 0, 0, 0);
+const offset = (ms, origin = noon) => new Date(origin.getTime() + ms);
+const label = makeTime => `${makeTime}`.slice(6);
+
+const future = {
+	seconds: n => offset(n * second),
+	minutes: n => offset(n * minute),
+	hours: (n, origin = noon) => offset(n * hour, origin),
+	days: n => offset(n * day),
+};
+
+const past = {
+	seconds: (n, origin = noon) => offset(-n * second, origin),
+	minutes: (n, origin = noon) => offset(-n * minute, origin),
+	hours: (n, origin = noon) => offset(-n * hour, origin),
+	days: (n, origin = noon) => offset(-n * day, origin),
+};
+
+const shortDateRegex = /^\d{1,2}\/\d{1,2}\/\d{4}$/;
+const shortDateTimeRegex = /^\d{1,2}\/\d{1,2}\/\d{4} \d{1,2}:\d{2} [AP]M$/;
+const fullDateRegex = /^\w+, \w+ \d{1,2}, \d{4}$/;
+const fullDateTimeRegex = /^\w+, \w+ \d{1,2}, \d{4} \d{1,2}:\d{2} [AP]M\s*$/;
+
+const enAlwaysShort = new Intl.RelativeTimeFormat('en', {
+	localeMatcher: 'best fit',
+	numeric: 'always',
+	style: 'short'
+});
+
+const frAutoLong = new Intl.RelativeTimeFormat('fr', {
+	localeMatcher: 'best fit',
+	numeric: 'auto',
+	style: 'long'
+});
+
+const relativeExamples = [
+	[() => past.seconds(1), '1 second ago', () => 29 * second],
+	[() => past.seconds(29), '29 seconds ago', () => 1 * second],
+	[() => future.seconds(1), 'in 1 second', () => 31 * second],
+	[() => future.seconds(28), 'in 28 seconds', () => 58 * second],
+	[() => past.seconds(30), 'this minute', () => 1 * minute],
+	[() => future.seconds(30), 'in 1 minute', () => 1 * minute],
+	[() => past.minutes(44), '44 minutes ago', () => 1 * minute],
+	[() => future.minutes(44), 'in 44 minutes', () => 1 * minute],
+	[() => past.minutes(45), '1 hour ago', () => 45 * minute],
+	[() => past.minutes(90.001), '2 hours ago', () => 1 * hour],
+	[() => past.minutes(100), '2 hours ago', () => 50 * minute],
+	[() => future.minutes(45), 'in 1 hour', () => 15 * minute],
+	[() => past.hours(5), '5 hours ago', () => 30 * minute],
+	[() => past.hours(5, threeAM), '5 hours ago', () => 30 * minute, { origin: threeAM }],
+	[() => future.hours(5), 'in 5 hours', () => 30 * minute],
+	[() => future.hours(5, ninePM), 'in 5 hours', () => 30 * minute, { origin: ninePM }],
+	[() => past.hours(6), '6 hours ago', () => 30 * minute],
+	[() => past.hours(6, threeAM), 'yesterday', () => 9 * hour, { origin: threeAM }],
+	[() => past.hours(27, threeAM), 'yesterday', () => 9 * hour, { origin: threeAM }],
+	[() => past.hours(27.001, threeAM), '2 days ago', () => 9 * hour, { origin: threeAM }],
+	[() => future.hours(6), 'in 6 hours', () => 30 * minute],
+	[() => future.hours(6, ninePM), 'tomorrow', () => 15 * hour, { origin: ninePM }],
+	[() => future.hours(26.999, ninePM), 'tomorrow', () => 15 * hour, { origin: ninePM }],
+	[() => future.hours(27, ninePM), 'in 2 days', () => 15 * hour, { origin: ninePM }],
+	[() => past.days(3.4999), '3 days ago', () => 24 * hour],
+	[() => future.days(3.4999), 'in 3 days', () => 24 * hour],
+	[() => past.days(1), 'yesterday', () => 24 * hour],
+	[() => past.days(1), '1 day ago', () => 24 * hour, { rtf: enAlwaysShort }],
+	[() => past.days(1), 'hier', () => 24 * hour, { rtf: frAutoLong }],
+	[() => past.minutes(23), '23 min. ago', () => 1 * minute, { rtf: enAlwaysShort }],
+];
+
+describe('fuzzyDateTime', () => {
+
+	describe('formatFuzzyDate', () => {
+		it('omits the time when formatting an absolute date', () => {
+			expect(formatFuzzyDate(past.days(5), { origin: noon })).to.match(shortDateRegex);
+			expect(formatFuzzyDate(future.days(5), { origin: noon })).to.match(shortDateRegex);
+		});
+
+		it('omits the time when formatting a long absolute date', () => {
+			expect(formatFuzzyDate(past.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateRegex);
+			expect(formatFuzzyDate(future.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateRegex);
+		});
+	});
+
+	describe('formatFuzzyDateTime', () => {
+		it('includes the time when formatting an absolute date', () => {
+			expect(formatFuzzyDateTime(past.days(5), { origin: noon })).to.match(shortDateTimeRegex);
+			expect(formatFuzzyDateTime(future.days(5), { origin: noon })).to.match(shortDateTimeRegex);
+		});
+
+		it('includes the time when formatting a long absolute date', () => {
+			expect(formatFuzzyDateTime(past.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateTimeRegex);
+			expect(formatFuzzyDateTime(future.days(5), { origin: noon, absoluteFormat: 'full' })).to.match(fullDateTimeRegex);
+		});
+
+	});
+
+	describe('formatFuzzy', () => {
+		describe('the readme examples', () => {
+
+			const origin = new Date(2015, 8, 23, 14, 5, 30);
+
+			const ruAlwaysShort = new Intl.RelativeTimeFormat('ru', {
+				localeMatcher: 'best fit',
+				numeric: 'always',
+				style: 'short'
+			});
+
+			it('example 1', () => {
+				expect(formatFuzzyDateTime(
+					new Date(2015, 8, 23, 14, 5, 18),
+					{ origin }
+				)).to.equal('12 seconds ago');
+			});
+
+			it('example 2', () => {
+				expect(formatFuzzyDateTime(
+					new Date(2015, 8, 24, 14, 5, 30),
+					{ origin, rtf: ruAlwaysShort }
+				)).to.equal('через 1 дн.');
+			});
+
+			it('example 3', async() => {
+				const invocations = [];
+				const actualDeltas = [];
+				const onUpdate = (text, opt) => {
+					invocations.push(text);
+					actualDeltas.push(opt.nextUpdateInMilliseconds);
+					return false;
+				};
+				const d = new Date(2015, 8, 23, 14, 5, 25);
+				const deltas = [
+					0,
+					25 * second,
+					1 * minute,
+					1 * minute,
+				];
+
+				let totalDelta = 0;
+				for (const delta of deltas) {
+					totalDelta += delta;
+					formatFuzzyDate(d, {
+						origin: new Date(origin.getTime() + totalDelta),
+						onUpdate
+					});
+				}
+				formatFuzzyDate(d, {
+					origin: new Date(origin.getTime() + 4 * day),
+					onUpdate,
+				});
+
+				deltas.push(1 * minute);
+				deltas.push(-1);
+				expect(actualDeltas).to.deep.equal(deltas.slice(1));
+				expect(invocations).to.deep.equal([
+					'5 seconds ago',
+					'this minute',
+					'1 minute ago',
+					'2 minutes ago',
+					'9/23/2015',
+				]);
+			});
+		});
+
+		it('uses absolute formatting for recent times when rtf is not available', () => {
+			expect(formatFuzzyDate(past.seconds(5), { origin: noon })).to.not.match(shortDateRegex);
+			expect(formatFuzzyDate(past.seconds(5), { origin: noon, rtf: false })).to.match(shortDateRegex);
+		});
+
+		relativeExamples.forEach(([makeTime, expected,, { rtf, origin = noon } = {}]) => {
+			it(`formats ${label(makeTime)} as ${expected}`, () => {
+				expect(formatFuzzyDateTime(makeTime(), { origin, rtf })).to.equal(expected);
+			});
+		});
+
+		it('formats > 3 days as absolute', () => {
+			expect(formatFuzzyDateTime(past.days(3.5))).to.match(shortDateTimeRegex);
+			expect(formatFuzzyDateTime(future.days(3.5))).to.match(shortDateTimeRegex);
+		});
+
+		for (const [makeTime,, expected, { origin = noon } = {}] of relativeExamples) {
+			it(`updates ${label(makeTime)} in ${label(expected)}`, (done) => {
+				formatFuzzyDateTime(makeTime(), {
+					origin,
+					onUpdate: (text, opt) => {
+						expect(opt.nextUpdateInMilliseconds)
+							.to.be.closeTo(expected(), 100);
+						done();
+						return false;
+					}
+				});
+			});
+		}
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -12,6 +12,7 @@
 		<script type="module" src="common.js"></script>
 		<script type="module" src="dateTime.js"></script>
 		<script type="module" src="fileSize.js"></script>
+		<script type="module" src="fuzzyDateTime.js"></script>
 		<script type="module" src="number.js"></script>
 		<script type="module">
 			mocha.checkLeaks();


### PR DESCRIPTION
From the readme:

## Fuzzy Date/Time Formatting

Dates and times can be "fuzzy" formatted in the user's locale using `formatFuzzyDate` and `formatFuzzyDateTime`. Here we define fuzzy formatting as automatically choosing a relative or absolute formatting based on the difference in time to another date called the `origin` (which is by default the current datetime).

- Relative formatting is used within 3 days of the origin. The [Intl.RelativeTimeFormat][] (`rtf`) web standard is used if available, otherwise the fuzzy functions default to absolute formatting. Some examples of relative formatting are:
  * `2 seconds ago`
  * `yesterday`
  * `tomorrow`
  * `in 3 days`
- Absolute formatting is used beyond 3 days from the origin. Options are forwarded to `formatDate` and `formatDateTime` in this case. See [Date/Time Formatting](#datetime-formatting) for details.

The `formatFuzzyDate` and `formatFuzzyDateTime` differ only in how they format absolutely. Relative formatting is the same for each.

```javascript
import {formatFuzzyDateTime} from '@brightspace-ui/intl/lib/fuzzyDateTime.js';

const origin = new Date(2015, 8, 23, 14, 5, 30);

formatFuzzyDateTime(
	new Date(2015, 8, 23, 14, 5, 18),
	{ origin } // omit for current datetime
); // -> '12 seconds ago' in en
```

Relative time formatting can be altered by providing a custom [Intl.RelativeTimeFormat][] object.

```javascript
const ruAlwaysShort = new Intl.RelativeTimeFormat('ru', {
	localeMatcher: 'best fit',
	numeric: 'always',
	style: 'short'
});

formatFuzzyDateTime(
	new Date(2015, 8, 24, 14, 5, 30),
	{ origin, rtf: ruAlwaysShort }
); // -> 'через 1 дн.'
```

Since relatively formatted values become incorrect as time passes, an optional callback `onUpdate` can be provided to get notified when the value should be changed.

```javascript
formatFuzzyDate(
	new Date(2015, 8, 23, 14, 5, 29),
	{ origin, onUpdate }
);
// onUpdate() gets invoked with:
// - '1 second ago'
// - '2 seconds ago'
// - '4 seconds ago'
// - '8 seconds ago'
// - '16 seconds ago'
// - '1 minute ago'
// - '2 minutes ago'
// - '3 minutes ago'
// ...
// - '3 days ago'
// - '9/23/2015'
```

Options:
- **absoluteFormat**: forwarded to `formatFuzzyDate` or `formatFuzzyDateTime` as `format` option.
- **origin**: a reference `Date` used to determine the relative time. By default `new Date()` is used (i.e. the current date/time)
- **onUpdate**: if provided, this callback will be invoked whenever the relative formatting needs to change
- **rtf**: an instance implementing the [Intl.RelativeTimeFormat][] web standard. By default the current locale is `best fit`, numeric is `auto`, and style is `long`.

[Intl.RelativeTimeFormat]:https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat
