### PR TITLE
Add data-oslo parsing

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -136,6 +136,7 @@ class DocumentLocaleSettings {
 		this.overrides = {};
 		this.timezone = {name: '', identifier: ''};
 		this._listeners = [];
+		this.oslo = {batch: null, collection: null};
 	}
 
 	sync() {
@@ -143,6 +144,7 @@ class DocumentLocaleSettings {
 		this.fallbackLanguage = this._htmlElem.getAttribute('data-lang-default');
 		this.overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
 		this.timezone = this._tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
+		this.oslo = this._tryParseHtmlElemAttr('data-oslo', {batch: null, collection: null});
 	}
 
 	_handleObserverChange(mutations) {
@@ -156,6 +158,8 @@ class DocumentLocaleSettings {
 				this.overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
 			} else if (mutation.attributeName === 'data-timezone') {
 				this.timezone = this._tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
+			} else if (mutation.attributeName === 'data-oslo') {
+				this.oslo = this._tryParseHtmlElemAttr('data-oslo', {batch: null, collection: null});
 			}
 		}
 	}

--- a/test/common.js
+++ b/test/common.js
@@ -112,13 +112,13 @@ describe('common', () => {
 		it('should default to null config', () => {
 			documentLocaleSettings.sync();
 			const value = documentLocaleSettings.oslo;
-			expect(value).to.deepEqual({ collection: null, batch: null });
+			expect(value).to.deep.equal({ collection: null, batch: null });
 		});
 		it('should parse json config', () => {
 			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/1","batch":"/path/to/2"}');
 			documentLocaleSettings.sync();
 			const value = documentLocaleSettings.oslo;
-			expect(value).to.deepEqual({ collection: '/path/to/1', batch: '/path/to/2' });
+			expect(value).to.deep.equal({ collection: '/path/to/1', batch: '/path/to/2' });
 		});
 	});
 

--- a/test/common.js
+++ b/test/common.js
@@ -112,22 +112,13 @@ describe('common', () => {
 		it('should default to null config', () => {
 			documentLocaleSettings.sync();
 			const value = documentLocaleSettings.oslo;
-			expect(value).to.equal({ collection: null, batch: null });
+			expect(value).to.deepEqual({ collection: null, batch: null });
 		});
 		it('should parse json config', () => {
 			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/1","batch":"/path/to/2"}');
 			documentLocaleSettings.sync();
 			const value = documentLocaleSettings.oslo;
-			expect(value).to.equal({ collection: '/path/to/1', batch: '/path/to/2' });
-		});
-		it('should update config if "data-oslo" gets set', (done) => {
-			const listener = () => {
-				expect(documentLocaleSettings.oslo).to.equal({ collection: '/path/to/3', batch: '/path/to/4' });
-				documentLocaleSettings.removeChangeListener(listener);
-				done();
-			};
-			documentLocaleSettings.addChangeListener(listener);
-			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/3","batch":"/path/to/4"}');
+			expect(value).to.deepEqual({ collection: '/path/to/1', batch: '/path/to/2' });
 		});
 	});
 

--- a/test/common.js
+++ b/test/common.js
@@ -19,6 +19,7 @@ describe('common', () => {
 		htmlElem.removeAttribute('data-lang-default');
 		htmlElem.removeAttribute('data-intl-overrides');
 		htmlElem.removeAttribute('data-timezone');
+		htmlElem.removeAttribute('data-oslo');
 		documentLocaleSettings.reset();
 	});
 
@@ -104,6 +105,29 @@ describe('common', () => {
 				const value = getLanguage();
 				expect(value).to.equal(baseLocale);
 			});
+		});
+	});
+
+	describe('oslo', () => {
+		it('should default to null config', () => {
+			documentLocaleSettings.sync();
+			const value = documentLocaleSettings.oslo;
+			expect(value).to.equal({ collection: null, batch: null });
+		});
+		it('should parse json config', () => {
+			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/1","batch":"/path/to/2"}');
+			documentLocaleSettings.sync();
+			const value = documentLocaleSettings.oslo;
+			expect(value).to.equal({ collection: '/path/to/1', batch: '/path/to/2' });
+		});
+		it('should update config if "data-oslo" gets set', (done) => {
+			const listener = () => {
+				expect(documentLocaleSettings.oslo).to.equal({ collection: '/path/to/3', batch: '/path/to/4' });
+				documentLocaleSettings.removeChangeListener(listener);
+				done();
+			};
+			documentLocaleSettings.addChangeListener(listener);
+			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/3","batch":"/path/to/4"}');
 		});
 	});
 


### PR DESCRIPTION
This PR adds `data-oslo` parsing, which will enable BrightspaceUI/core to opt into Oslo features when supported by the LMS.

I couldn't run the tests locally, on my branch or on unchanged master:

```
ppaskaris@KDX1-PPASKARIS:/c/D2L/aux-src/intl (master)
$ npm test

> @brightspace-ui/intl@3.0.6 test C:\D2L\aux-src\intl
> npm run lint -s && npm run test:unit -s

[test]
[test] TimeoutError: waiting for function failed: timeout 60000ms exceeded
[test]     at new WaitTask (C:\D2L\aux-src\intl\node_modules\puppeteer\lib\DOMWorld.js:549:28)
[test]     at DOMWorld.waitForFunction (C:\D2L\aux-src\intl\node_modules\puppeteer\lib\DOMWorld.js:454:12)
[test]     at Frame.waitForFunction (C:\D2L\aux-src\intl\node_modules\puppeteer\lib\FrameManager.js:657:28)
[test]     at Page.waitForFunction (C:\D2L\aux-src\intl\node_modules\puppeteer\lib\Page.js:1114:29)
[test]     at C:\D2L\aux-src\intl\node_modules\mocha-headless-chrome\lib\runner.js:186:42
[test]     at processTicksAndRejections (internal/process/task_queues.js:97:5) {
[test]   name: 'TimeoutError'
[test] }
[test] mocha-headless-chrome -f http://localhost:8080/test/index.html -a no-sandbox -a disable-setuid-sandbox exited with code 1
--> Sending SIGTERM to other processes..
[serve] http-server -p 8080 . -s exited with code 1
npm ERR! Test failed.  See above for more details.
```