### PR TITLE
handling group sizes again

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -11,7 +11,7 @@ function formatPositiveInteger(value, descriptor) {
 	const valueStr = '' + value;
 	let ret = '';
 
-	const groupSizes = [3];
+	const groupSizes = Array.isArray(descriptor.groupSize) ? descriptor.groupSize : [descriptor.groupSize];
 	let currentGroupSizeIndex = -1;
 	const maxGroupSizeIndex = groupSizes.length - 1;
 	let currentGroupSize = 0;
@@ -157,6 +157,7 @@ export function getNumberDescriptor() {
 	}
 
 	const descriptor = {
+		groupSize: 3,
 		patterns: {
 			decimal: {
 				positivePattern: '{number}',

--- a/test/number.js
+++ b/test/number.js
@@ -152,6 +152,29 @@ describe('number', () => {
 				});
 			});
 
+			it('should use custom group size', () => {
+				documentLocaleSettings.overrides = {number: {groupSize: 5}};
+				const value = formatNumber(1000000);
+				expect(value).to.equal('10,00000');
+			});
+
+			it('should handle group size of 0', () => {
+				documentLocaleSettings.overrides = {number: {groupSize: 0}};
+				const value = formatNumber(1000000.01, {maximumFractionDigits: 2});
+				expect(value).to.equal('1000000.01');
+			});
+
+			[
+				{ val: 1000000000.01, groupSize:[3, 2, 1, 0], expected: '1000,0,00,000.01' },
+				{ val: 123456789.123, groupSize:[4, 2], expected: '1,23,45,6789.12' }
+			].forEach(function(input) {
+				it('should handle variable group sizes', () => {
+					documentLocaleSettings.overrides = {number: {groupSize: input.groupSize}};
+					const value = formatNumber(input.val, {maximumFractionDigits: 2});
+					expect(value).to.equal(input.expected);
+				});
+			});
+
 		});
 
 		[


### PR DESCRIPTION
I had mistakenly thought that custom group sizes -- including group sizes of zero -- weren't possible from the LMS. But they are via user account settings.

Without this support, group sizes of zero are formatted using a comma as a separator resulting in "1,000" instead of "1000" which in legacy fails to parse.