### PR TITLE
Edge (legacy): Date.parse bug

### DIFF
--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -32,6 +32,19 @@ function formatDateString(date) {
 	return formatter.format(date);
 }
 
+function getDateStringWithTimezone(date, timezone) {
+	let dateString = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${timezone}`;
+	if (timezone.includes('-') || timezone.includes('+')) {
+		const re = /([A-Z]{3})(\+|-)([0-9]{1,2}):([0-9]{2})/;
+		const match = timezone.match(re);
+		if (match && match.length === 5) {
+			// YYYY-MM-DDTHH:mm:ss(+|-)HH:MM
+			dateString = `${date.year}-${date.month}-${date.date}T${date.hours}:${date.minutes}:${date.seconds}${match[2]}${prePadByZero(match[3], 2)}:${prePadByZero(match[4], 2)}`;
+		}
+	}
+	return dateString;
+}
+
 function getParts() {
 
 	const descriptor = getDateTimeDescriptor();
@@ -208,13 +221,21 @@ export function convertLocalToUTCDateTime(date) {
 	}
 
 	const dateDate = new Date(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds);
+	const datePrePad = {
+		year: date.year,
+		month: prePadByZero(date.month, 2),
+		date: prePadByZero(date.date, 2),
+		hours: prePadByZero(date.hours, 2),
+		minutes: prePadByZero(date.minutes, 2),
+		seconds: prePadByZero(date.seconds, 2)
+	};
 	const timezone = formatDateString(dateDate).split(' ')[2];
-	const dateString = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${timezone}`;
+	const dateString = getDateStringWithTimezone(datePrePad, timezone);
 	const parsedDateString = new Date(Date.parse(dateString));
 
 	// run again in case of DST (e.g., if timezone is CST for dateDate but local time is after CST is over, timezone is incorrect)
 	const utcCorrectedTimezone = formatDateString(parsedDateString).split(' ')[2];
-	const dateStringInTimezone = `${date.month}/${date.date}/${date.year}, ${date.hours}:${date.minutes}:${date.seconds} ${utcCorrectedTimezone}`;
+	const dateStringInTimezone = getDateStringWithTimezone(datePrePad, utcCorrectedTimezone);
 	const utcCorrectedDate = new Date(Date.parse(dateStringInTimezone));
 
 	return {

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -159,6 +159,7 @@ describe('dateTime', () => {
 
 			[
 				{timezone: 'Pacific/Rarotonga', expectedGMTOffset: -10},
+				{timezone: 'Pacific/Marquesas', expectedGMTOffset: -9.5},
 				{timezone: 'America/Santa_Isabel', expectedGMTOffset: -8},
 				{timezone: 'America/Toronto', expectedGMTOffset: -5},
 				{timezone: 'Atlantic/Reykjavik', expectedGMTOffset: 0},


### PR DESCRIPTION
A bug was found when running the tests in brightspaceUI/core in edge legacy where `convertLocalToUTCDateTime` was not working. It turns out that `Date.parse` doesn't work well in edge legacy when timezone is formatted like `GMT+8:45` and requires a timezone string more like `YYYY-MM-DDTHH:mm:ss(+|-)HH:MM` in that case (it does work fine with timezones like `EST` - when timezone is a full hour (e.g., -5) it returns more of a string format, whereas when it is something like -9.5 it returns that `GMT-9:30` format where the problem lies). 