### PR TITLE
Add version prop to oslo config

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -136,7 +136,7 @@ class DocumentLocaleSettings {
 		this.overrides = {};
 		this.timezone = {name: '', identifier: ''};
 		this._listeners = [];
-		this.oslo = {batch: null, collection: null};
+		this.oslo = {batch: null, collection: null, version: null};
 	}
 
 	sync() {
@@ -144,7 +144,7 @@ class DocumentLocaleSettings {
 		this.fallbackLanguage = this._htmlElem.getAttribute('data-lang-default');
 		this.overrides = this._tryParseHtmlElemAttr('data-intl-overrides', {});
 		this.timezone = this._tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
-		this.oslo = this._tryParseHtmlElemAttr('data-oslo', {batch: null, collection: null});
+		this.oslo = this._tryParseHtmlElemAttr('data-oslo', {batch: null, collection: null, version: null});
 	}
 
 	_handleObserverChange(mutations) {
@@ -159,7 +159,7 @@ class DocumentLocaleSettings {
 			} else if (mutation.attributeName === 'data-timezone') {
 				this.timezone = this._tryParseHtmlElemAttr('data-timezone', {name: '', identifier: ''});
 			} else if (mutation.attributeName === 'data-oslo') {
-				this.oslo = this._tryParseHtmlElemAttr('data-oslo', {batch: null, collection: null});
+				this.oslo = this._tryParseHtmlElemAttr('data-oslo', {batch: null, collection: null, version: null});
 			}
 		}
 	}

--- a/test/common.js
+++ b/test/common.js
@@ -112,13 +112,13 @@ describe('common', () => {
 		it('should default to null config', () => {
 			documentLocaleSettings.sync();
 			const value = documentLocaleSettings.oslo;
-			expect(value).to.deep.equal({ collection: null, batch: null });
+			expect(value).to.deep.equal({ collection: null, batch: null, version: null });
 		});
 		it('should parse json config', () => {
-			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/1","batch":"/path/to/2"}');
+			htmlElem.setAttribute('data-oslo', '{"collection":"/path/to/1","batch":"/path/to/2","version":"abc123"}');
 			documentLocaleSettings.sync();
 			const value = documentLocaleSettings.oslo;
-			expect(value).to.deep.equal({ collection: '/path/to/1', batch: '/path/to/2' });
+			expect(value).to.deep.equal({ collection: '/path/to/1', batch: '/path/to/2', version: 'abc123' });
 		});
 	});
 


### PR DESCRIPTION
This PR adds the `version` property to the Oslo configuration, which enables the client to maintain its cache.