### PR TITLE
Bug fix: use hourCycle instead of hour12

### DIFF
--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -22,7 +22,7 @@ function formatDateString(date) {
 		hour: '2-digit',
 		minute: '2-digit',
 		second: '2-digit',
-		hour12: false,
+		hourCycle: 'h23'
 	};
 	if (timezone) {
 		options.timeZone = timezone;

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-html": "^6",
     "eslint-plugin-sort-class-members": "^1",
     "http-server": "^0.12",
-    "mocha": "^8",
+    "mocha": "~8.0.1",
     "mocha-headless-chrome": "^3",
     "semantic-release": "^17"
   },

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -85,6 +85,21 @@ describe('dateTime', () => {
 				}).to.throw();
 			});
 
+			it('should have expected GMT offset of -5 for timezone America/Toronto at midnight', () => {
+				documentLocaleSettings.timezone.identifier = 'America/Toronto';
+				const UTCDateTime2 = {
+					month: 2,
+					date: 27,
+					year: 2015,
+					hours: 5,
+					minutes: 0,
+					seconds: 0
+				};
+				const result = convertUTCToLocalDateTime(UTCDateTime2);
+				const expectedResult = getExpectedResult(UTCDateTime2, -5);
+				expect(result).to.deep.equal(expectedResult);
+			});
+
 			[
 				{timezone: 'Pacific/Rarotonga', expectedGMTOffset: -10},
 				{timezone: 'America/Santa_Isabel', expectedGMTOffset: -7},


### PR DESCRIPTION
I noticed the following behavior when using `formatDateString` to parse `Tue Feb 27 2018 00:00:00 GMT-0500 (Eastern Standard Time)`.

In chrome:
Becomes `02/27/2018, 24:00:00 EST` (INCORRECT)

In Firefox:
Becomes `02/27/2018, 00:00:00 EST` (CORRECT)

This 24hr time was causing dates to appear as the next day (e.g., would be displayed as Feb 28, 2018 12 AM)

I found this thread https://support.google.com/chrome/thread/29828561?hl=en that mentions this and a reply suggest to use `hourCycle: h23` and remove `hour12`, which does seem to fix it in my use case.