### PR TITLE
fix: also check for Atlantic region for AST and ADT

### DIFF
--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -346,19 +346,21 @@ function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 		case 'ADT':
 			// Arabia Daylight Time +0400 (Asia)
 			// Atlantic Daylight Time -0300 (America)
-			return longTimezone.includes('America') ? '-0300' : '+0400';
+			if (longTimezone.includes('America') || longTimezone.includes('Atlantic')) return '-0300';
+			else return '+0400';
 		case 'AMT':
 			// Amazon Time (Brazil) -0400 (America)
 			// Armenia Time +0400 (Asia)
-			return longTimezone.includes('America') ? '-0400' : '+0400';
+			return longTimezone.includes('Asia') ? '+0400' : '-0400';
 		case 'AMST':
 			// Amazon Summer Time -0300 (America)
 			// Armenia Summer Time +0500 (Asia)
-			return longTimezone.includes('America') ? '-0300' : '+0500';
+			return longTimezone.includes('Asia') ? '+0500' : '-0300';
 		case 'AST':
 			// Atlantic Standard Time -0400 (America)
 			// Arabia Standard Time +0300 (Asia)
-			return longTimezone.includes('America') ? '-0400' : '+0300';
+			if (longTimezone.includes('America') || longTimezone.includes('Atlantic')) return '-0400';
+			else return '+0300';
 		case 'AT':
 			// Alaska Time -0900 (America/Anchorage, America/Juneau, America/Nome, America/Sitka, America/Yakutat)
 			// Atlantic Time -0400 (America)
@@ -372,8 +374,8 @@ function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 			} else return '-0400';
 		case 'BDT':
 			// British Daylight Time +0100 (Europe)
-			// Brunei Time +0800
-			return longTimezone.includes('Europe') ? '+0100' : '+0800';
+			// Brunei Time +0800 (Asia)
+			return longTimezone.includes('Asia') ? '+0800' : '+0100';
 		case 'BST':
 			// Bangladesh Standard Time +0600 (Asia)
 			// British Summer Time +0100 (Europe)
@@ -381,28 +383,28 @@ function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 			// Brazilian Summer Time -0200 (America)
 			if (longTimezone.includes('Asia')) return '+0600';
 			else if (longTimezone.includes('Pacific')) return '+1100';
-			else if (longTimezone.includes('America')) return '-0200';
-			else return '+0100';
+			else if (longTimezone.includes('Europe')) return '+0100';
+			else return '-0200';
 		case 'CDST':
 			// Central Daylight Savings Time +1030 (Australia)
 			// Central Daylight Saving Time -0500 (America)
-			return longTimezone.includes('America') ? '-0500' : '+1030';
+			return longTimezone.includes('Australia') ? '+1030' : '-0500';
 		case 'CDT':
 			// Central Daylight Time -0500 (America)
 			// Cuba Daylight Time -0400 (America/Havana)
 			// Central Daylight Time +1030 (Australia)
 			if (longTimezone === 'America/Havana') return '-0400';
-			else if (longTimezone.includes('America')) return '-0500';
-			else return '+1030';
+			else if (longTimezone.includes('Australia')) return '+1030';
+			else return '-0500';
 		case 'CST':
 			// Cuba Standard Time -0500 (America/Havana)
 			// Central Standard Time -0600 (America)
 			// China Standard Time +0800 (Asia)
 			// Australian Central Standard Time +0930 (Australia)
 			if (longTimezone === 'America/Havana') return '-0500';
-			else if (longTimezone.includes('America')) return '-0600';
+			else if (longTimezone.includes('Asia')) return '+0800';
 			else if (longTimezone.includes('Australia')) return '+0930';
-			else return '+0800';
+			else return '-0600';
 		case 'ECT':
 			// European Central Time +0100 (Europe, Africa)
 			// Ecuador Time -0500 (America)
@@ -411,11 +413,12 @@ function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 		case 'EDST':
 			// Eastern Daylight Time +1100 (Australia)
 			// Eastern Daylight Time -0400 (America)
-			return longTimezone.includes('America') ? '-0400' : '+1100';
+			if (longTimezone.includes('Antarctica') || longTimezone.includes('Australia')) return '+1100';
+			else return '-0400';
 		case 'EST':
 			// Eastern Standard Time +1000 (Australia)
 			// Eastern Standard Time -0500 (America)
-			return longTimezone.includes('America') ? '-0500' : '+1000';
+			return longTimezone.includes('Australia') ? '+1000' : '-0500';
 		case 'GST':
 			// South Georgia and the South Sandwich Islands Time -0200 (Atlantic)
 			// Gulf Standard Time +0400 (Asia)
@@ -437,18 +440,18 @@ function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 		case 'MST':
 			// Malaysia Standard Time +0800 (Asia)
 			// Mountain Standard Time -0700 (America)
-			return longTimezone.includes('America') ? '-0700' : '+0800';
+			return longTimezone.includes('Asia') ? '+0800' : '-0700';
 		case 'PST':
 			// Pacific Standard Time -0800 (America)
 			// Philippine Standard Time +0800 (Asia)
-			return longTimezone.includes('America') ? '-0800' : '+0800';
+			return longTimezone.includes('Asia') ? '+0800' : '-0800';
 		case 'PYST':
 			// Pyongyan Time +0830 (Asia)
 			// Paraguay Summer Time -0300 (America)
 			return longTimezone.includes('Asia') ? '+0830' : '-0300';
 		case 'PYT':
 			// Paraguary Time -0400 (South America)
-			// Pyongyan Time +0830 (Asia)
+			// Pyongyang Time +0830 (Asia)
 			return longTimezone.includes('Asia') ? '+0830' : '-0400';
 		case 'SST':
 			// Singapore Standard Time +0800 (Asia)


### PR DESCRIPTION
Bermuda is also in AST/ADT and its name started with `Atlantic` so I added the check for that as well. For the other duplicates I verified what region(s) they were used in and modified to check for the simpler one in the if statement just in case.