### PR TITLE
cleanup: remove WIP warning from README, alphabetize functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,6 @@ date.getMinutes(); // -> 5
 
 ## Date/Time Conversion based on user timezone
 
-**These are a work in progress and are not ready for usage yet**
-
 To convert an object containing a UTC date to an object containing a local date corresponding to the `data-timezone` attribute:
 ```javascript
 import {convertUTCToLocalDateTime} from '@brightspace-ui/intl/lib/dateTime.js';

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -346,6 +346,78 @@ function getDateStringWithTimezone(date, timezone) {
 	return dateString;
 }
 
+function getParts() {
+
+	const descriptor = getDateTimeDescriptor();
+
+	const result = [];
+	const separator = getSeparator();
+	const parts = descriptor.formats.dateFormats.short.split(separator);
+
+	for (var i = 0; i < parts.length; i++) {
+		var part = parts[i].trim();
+		switch (part) {
+			case 'dd':
+			case 'd':
+				result.push('d');
+				break;
+			case 'MM':
+			case 'M':
+				result.push('M');
+				break;
+			case 'yyyy':
+				result.push('yyyy');
+				break;
+		}
+	}
+
+	if (result.length !== 3) {
+		return ['M', 'd', 'yyyy'];
+	}
+
+	return result;
+
+}
+
+const reSeparator = new RegExp('\\W');
+
+function getSeparator() {
+	const descriptor = getDateTimeDescriptor();
+	const match = reSeparator.exec(descriptor.formats.dateFormats.short);
+	if (match !== null) {
+		return match[0];
+	}
+	return '/';
+}
+
+function getTimeFormat(hour24, language, baseLanguage) {
+
+	if (hour24 && baseLanguage === 'fr') {
+		return 'HH\' h \'mm';
+	}
+
+	let timeFormat = hour24 ? 'HH:mm' : 'h:mm';
+
+	// non-zero padded 24-hour clocks and zero-padded 12-hour clocks
+	if (hour24 && (baseLanguage === 'ja' || language === 'pt-br' || (baseLanguage === 'zh' && language !== 'zh-tw'))) {
+		timeFormat = 'H:mm';
+	} else if (!hour24 && language === 'zh-tw') {
+		timeFormat = 'hh:mm';
+	}
+
+	if (!hour24) {
+		// AM/PM before vs. after
+		if (baseLanguage === 'ko' || baseLanguage === 'zh') {
+			timeFormat = `tt ${timeFormat}`;
+		} else {
+			timeFormat = `${timeFormat} tt`;
+		}
+	}
+
+	return timeFormat;
+
+}
+
 function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 	const longTimezone = getDocumentLocaleSettings().timezone.identifier;
 	switch (abbrTimezone) {
@@ -490,78 +562,6 @@ function getTimezoneFromDuplicatedAbbreviation(abbrTimezone) {
 	}
 }
 
-function getParts() {
-
-	const descriptor = getDateTimeDescriptor();
-
-	const result = [];
-	const separator = getSeparator();
-	const parts = descriptor.formats.dateFormats.short.split(separator);
-
-	for (var i = 0; i < parts.length; i++) {
-		var part = parts[i].trim();
-		switch (part) {
-			case 'dd':
-			case 'd':
-				result.push('d');
-				break;
-			case 'MM':
-			case 'M':
-				result.push('M');
-				break;
-			case 'yyyy':
-				result.push('yyyy');
-				break;
-		}
-	}
-
-	if (result.length !== 3) {
-		return ['M', 'd', 'yyyy'];
-	}
-
-	return result;
-
-}
-
-const reSeparator = new RegExp('\\W');
-
-function getSeparator() {
-	const descriptor = getDateTimeDescriptor();
-	const match = reSeparator.exec(descriptor.formats.dateFormats.short);
-	if (match !== null) {
-		return match[0];
-	}
-	return '/';
-}
-
-function getTimeFormat(hour24, language, baseLanguage) {
-
-	if (hour24 && baseLanguage === 'fr') {
-		return 'HH\' h \'mm';
-	}
-
-	let timeFormat = hour24 ? 'HH:mm' : 'h:mm';
-
-	// non-zero padded 24-hour clocks and zero-padded 12-hour clocks
-	if (hour24 && (baseLanguage === 'ja' || language === 'pt-br' || (baseLanguage === 'zh' && language !== 'zh-tw'))) {
-		timeFormat = 'H:mm';
-	} else if (!hour24 && language === 'zh-tw') {
-		timeFormat = 'hh:mm';
-	}
-
-	if (!hour24) {
-		// AM/PM before vs. after
-		if (baseLanguage === 'ko' || baseLanguage === 'zh') {
-			timeFormat = `tt ${timeFormat}`;
-		} else {
-			timeFormat = `${timeFormat} tt`;
-		}
-	}
-
-	return timeFormat;
-
-}
-
 function isDateValid(year, month, day) {
 
 	if (isNaN(year) || year < 1753 || year > 9999) {
@@ -639,14 +639,6 @@ function processPattern(pattern, replacements) {
 
 }
 
-export function convertUTCToLocalDateTime(date) {
-	if (!getDocumentLocaleSettings().timezone.identifier) {
-		return date;
-	}
-	const utcDate = new Date(Date.UTC(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds));
-	return convertJsDateToLocalDateTime(utcDate) || date;
-}
-
 export function convertLocalToUTCDateTime(date) {
 	if (!getDocumentLocaleSettings().timezone.identifier) {
 		return date;
@@ -688,6 +680,14 @@ export function convertLocalToUTCDateTime(date) {
 		minutes: utcCorrectedDate.getUTCMinutes(),
 		seconds: utcCorrectedDate.getUTCSeconds()
 	};
+}
+
+export function convertUTCToLocalDateTime(date) {
+	if (!getDocumentLocaleSettings().timezone.identifier) {
+		return date;
+	}
+	const utcDate = new Date(Date.UTC(date.year, date.month - 1, date.date, date.hours, date.minutes, date.seconds));
+	return convertJsDateToLocalDateTime(utcDate) || date;
 }
 
 export function getDateTimeDescriptor() {


### PR DESCRIPTION
No code was actually changed, just moved around. The formatTime/parseTime etc functions are not technically in order but they're paired up nicely so I left them as is (though open to moving them as well). Most of the reorganization was with the helper functions.