### PR TITLE
fixing floating point precision error when formatting decimals

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -205,7 +205,8 @@ function formatDecimal(value, options) {
 	let decimalStr = null;
 
 	if (hasDecimal) {
-		const decimalValue = Math.round((value - integerValue) * precisionScaling) / precisionScaling;
+		let decimalValue = (value * precisionScaling - integerValue * precisionScaling) / precisionScaling;
+		decimalValue =  Math.round(decimalValue * precisionScaling) / precisionScaling;
 
 		// get a string of 0.xxx, or exponent of x.xe-x
 		decimalStr = '' + decimalValue;

--- a/test/number.js
+++ b/test/number.js
@@ -62,7 +62,8 @@ describe('number', () => {
 				{ val: 1e10, expect: '10,000,000,000' },
 				{ val: 6.845e13, expect: '68,450,000,000,000' },
 				{ val: 12345678901.123456789, max: 3, expect: '12,345,678,901.123' },
-				{ val: -12345678901.123456789, max: 3, expect: '-12,345,678,901.123' }
+				{ val: -12345678901.123456789, max: 3, expect: '-12,345,678,901.123' },
+				{ val: 5.2, max: 20, expect: '5.2' }
 			].forEach(function(input) {
 				it(`should format ${input.val}, max:${input.max}, min:${input.min}`, () => {
 					const options = {


### PR DESCRIPTION
Dealing with operations on floating point numbers in JavaScript is pretty weird -- the common example being `0.1 + 0.2 !== 0.3`. The reason for this of course is that precision gets lost in the conversion from base 10 to binary.

This appeared as a bug in our new numeric input, where if a precision of 15 digits was requested, `5.2` gets instantly reformatted as `5.2000000000000002` -- not ideal.

The [general advice around this](https://www.avioconsulting.com/blog/overcoming-javascript-numeric-precision-issues#:~:text=In%20Javascript%2C%20all%20numbers%20are,the%20sign%20in%20bit%2063.) is to multiple by 10 to the power of whatever precision you need, do the operation (like addition/subtraction, etc.) and then divide back by that same value.

So that's the solution I went with here when it's performing a subtraction operation to remove the "integer" portion of a decimal number.
