### PR TITLE
fix: switching to use native formatNumber API

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -43,18 +43,6 @@ function formatPositiveInteger(value, descriptor) {
 	return ret;
 }
 
-function formatExponentialDecimal(value) {
-	// Get a value should be like "1.25e-8"
-	const pieces = value.split('e-');
-	let ret = pieces[0].replace('.', '');
-	const zeroCount = parseInt(pieces[1]) - 1;
-
-	for (let i = 0; i < zeroCount; i++) {
-		ret = '0' + ret;
-	}
-	return ret;
-}
-
 function validateFormatOptions(options) {
 
 	options = options || {};
@@ -192,41 +180,23 @@ function formatDecimal(value, options) {
 	options = validateFormatOptions(options);
 
 	const isNegative = value < 0;
+	value = Math.abs(value);
 
-	const precisionScaling = Math.pow(10, options.maximumFractionDigits);
-	// round to desired precision
-	value = Math.abs(Math.round(value * precisionScaling) / precisionScaling);
-
-	const integerValue = Math.floor(value);
-
-	let ret = formatPositiveInteger(integerValue, descriptor);
-
-	const hasDecimal = value !== integerValue;
-	let decimalStr = null;
-
-	if (hasDecimal) {
-		let decimalValue = (value * precisionScaling - integerValue * precisionScaling) / precisionScaling;
-		decimalValue =  Math.round(decimalValue * precisionScaling) / precisionScaling;
-
-		// get a string of 0.xxx, or exponent of x.xe-x
-		decimalStr = '' + decimalValue;
-
-		if (decimalValue.toExponential() === decimalStr) {
-			// Get a string with leading zeros
-			decimalStr = formatExponentialDecimal(decimalStr);
-		} else {
-			// the first decimal place is index 2
-			decimalStr = decimalStr.slice(2);
+	const strValue = new Intl.NumberFormat(
+		'en-US',
+		{
+			signDisplay: 'never',
+			maximumFractionDigits: options.maximumFractionDigits,
+			minimumFractionDigits: options.minimumFractionDigits,
+			useGrouping: false
 		}
-	} else if (options.minimumFractionDigits > 0) {
-		decimalStr = '';
-	}
+	).format(value);
 
-	if (decimalStr !== null) {
-		while (decimalStr.length < options.minimumFractionDigits) {
-			decimalStr += '0';
-		}
-		ret += descriptor.symbols.decimal + decimalStr;
+	let ret = formatPositiveInteger(parseInt(strValue), descriptor);
+
+	const decimalIndex = strValue.indexOf('.');
+	if (decimalIndex > -1) {
+		ret += descriptor.symbols.decimal + strValue.substr(decimalIndex + 1);
 	}
 
 	const pattern = isNegative

--- a/test/number.js
+++ b/test/number.js
@@ -63,7 +63,10 @@ describe('number', () => {
 				{ val: 6.845e13, expect: '68,450,000,000,000' },
 				{ val: 12345678901.123456789, max: 3, expect: '12,345,678,901.123' },
 				{ val: -12345678901.123456789, max: 3, expect: '-12,345,678,901.123' },
-				{ val: 5.2, max: 20, expect: '5.2' }
+				{ val: 5.2, max: 20, expect: '5.2' },
+				{ val: -5.2, max: 20, expect: '-5.2' },
+				{ val: 9999999999.1, max: 20, expect: '9,999,999,999.1' },
+				{ val: 99999.133, max: 20, expect: '99,999.133' }
 			].forEach(function(input) {
 				it(`should format ${input.val}, max:${input.max}, min:${input.min}`, () => {
 					const options = {


### PR DESCRIPTION
We're still seeing floating point rounding problems when the number of digits + the requested precision (15 digits from the LMS) exceeds the maximum integer size in JavaScript (`2^53`). For example, `99,999` with a precision of 15 digits resulted in `99,000 x 10^15` being greater than `2^53` so rounding occurs and precision is lost.

So I decided to go back to the drawing board and do something with our Intl stuff that I've wanted to do for a while -- just call into the native `Intl.MessageFormat` APIs! What a concept! The trick here is that we just pass in a known locale (the `en-US` one) where we know the decimal separator will be a period. Then we can grab the stuff before/after the period and re-format it using our crazy rules.

Bonus: it supports max/min fraction digits and handles all the rounding and zero-padding for us!

[Browser support](https://caniuse.com/mdn-javascript_builtins_intl_numberformat_format) seems good: IE11, Edge 12+, Firefox 29+, Chrome 24+ Safari 10+.