### PR TITLE
feat: adding a useGrouping option for number formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ const percent = formatPercent(0.333, [options]); // -> '33.3 %' in en-US
 Options:
 - **minimumFractionDigits**: Minimum number of fraction digits to use. Possible values range from `0` to `20`; the default is `0`.
 - **maximumFractionDigits**: Maximum number of fraction digits to use. Possible values range from `0` to `20`; the default is the larger of `minimumFractionDigits` and `3`.
+- **useGrouping**: Whether to use grouping separators, such as thousands separators; the default is `true`.
 
 Formatting as an integer (rounded to 0 decimal places):
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -5,8 +5,12 @@ import {
 	validateFormatValue
 } from './common.js';
 
-function formatPositiveInteger(value, descriptor) {
+function formatPositiveInteger(value, descriptor, useGrouping) {
 	value = Math.floor(value);
+
+	if (!useGrouping) {
+		return value.toString();
+	}
 
 	const valueStr = '' + value;
 	let ret = '';
@@ -47,6 +51,7 @@ function validateFormatOptions(options) {
 
 	options = options || {};
 
+	options.useGrouping = options.useGrouping !== false;
 	if (options.style !== 'decimal' && options.style !== 'percent') {
 		options.style = 'decimal';
 	}
@@ -192,7 +197,7 @@ function formatDecimal(value, options) {
 		}
 	).format(value);
 
-	let ret = formatPositiveInteger(parseInt(strValue), descriptor);
+	let ret = formatPositiveInteger(parseInt(strValue), descriptor, options.useGrouping);
 
 	const decimalIndex = strValue.indexOf('.');
 	if (decimalIndex > -1) {

--- a/test/number.js
+++ b/test/number.js
@@ -145,6 +145,11 @@ describe('number', () => {
 				});
 			});
 
+			it('should not include group separators when "useGrouping" is false', () => {
+				const value = formatNumber(1234567.891, { useGrouping: false });
+				expect(value).to.equal('1234567.891');
+			});
+
 			[
 				{ symbol: '|@|', expected: '1|@|000|@|000' },
 				{ symbol: '\'', expected: '1\'000\'000' }


### PR DESCRIPTION
Within our number input web component, we've decided that we'd like to suppress showing the thousand separators in the input itself. These can be confusing to see in an input, especially when you're trying to change a value by adding/removing digits -- in these cases you need to fix where the thousand separators are before it'll validate.

This is why it's not common to see thousand separators in number inputs -- `<input type="number">` doesn't show them, and tools like Excel/Google Sheets only show them where a number is rendered, not where it's inputted.

This change adds an option to suppress thousand separators from `formatNumber()` -- it follows the same naming convention as the native [Intl NumberFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat) does.