### PR TITLE
fix Safari 14.1 NumberFormat issue

### DIFF
--- a/lib/number.js
+++ b/lib/number.js
@@ -190,7 +190,6 @@ function formatDecimal(value, options) {
 	const strValue = new Intl.NumberFormat(
 		'en-US',
 		{
-			signDisplay: 'never',
 			maximumFractionDigits: options.maximumFractionDigits,
 			minimumFractionDigits: options.minimumFractionDigits,
 			useGrouping: false


### PR DESCRIPTION
There's a weird issue with `Intl.NumberFormat` that Apple introduced in Safari 14.1 that only affects macOS Mojave users (10.14). If you use the `signDisplay` option, [it throws an exception](https://github.com/WebKit/WebKit/blob/9cb35748705901155cb6d83963671c791046c035/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp#L586) with the message `Failed to initialize NumberFormat since used feature is not supported in the linked ICU version`. This is not a problem on later versions of macOS.

Our usage here of the `signDisplay` option wasn't necessary anyway, since we take the absolute value of the number on the line above and then add in the negative symbol later anyway.

Apple [has addressed the issue](https://trac.webkit.org/changeset/278697/webkit), but it's not clear when that will be released.