### PR TITLE
fix: correct readME about medium format

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const date = formatDateTime(
 Options:
 - **format**: pattern to use when rendering the date-time; default is `'short'`.
   - **full**: long weekday, month names and timezone. e.g. `'Wednesday, September 23, 2015 1:25 PM EST'`
-  - **medium**: long month names. e.g. `'September 23, 2015 1:25 PM'`
+  - **medium**: short month names. e.g. `'Sept 23, 2015 1:25 PM'`
   - **short**: abbreviated date format. e.g. `'9/23/2015 1:25 PM'`
 
 To format a **timestamp** as a date and time:


### PR DESCRIPTION
I found that the 'medium' format actually maps to 'MMM d, yyyy' instead of 'MMMM d, yyyy' for English (and a few other languages). Just fixing the docs to match the implementation