### PR TITLE
Added helpers for formatting timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ const dateString = formatDateTimeFromTimestamp(
 Options are the same as for `formatDateTime`; this method converts the timestamp to a `Date` in the user's
 configured time zone, then returns the results of passing this date to `formatDateTime`.
 
+To format a **timestamp** as a date only:
+
+```javascript
+const dateString = formatDateFromTimestamp(
+	1607097863123,
+	[options]
+);
+```
+
+Options are the same as for `formatDate`; this method converts the timestamp to a `Date` in the user's
+configured time zone, then returns the results of passing this date to `formatDate`.
+
+To format a **timestamp** as a time only:
+
+```javascript
+const timeString = formatTimeFromTimestamp(
+	1607097863123,
+	[options]
+);
+```
+
+Options are the same as for `formatTime`; this method converts the timestamp to a `Date` in the user's
+configured time zone, then returns the results of passing this date to `formatTime`.
+
 To format a **date only** (without the time portion), use `formatDate`:
 
 ```javascript

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -1128,24 +1128,24 @@ export function formatDateTime(date, options) {
 
 }
 
-function parseLocalDateTimeFromTimestamp(timestamp, options) {
+function parseLocalDateTimeFromTimestamp(timestamp) {
 	const utcDate = new Date(timestamp);
 	const local = convertJsDateToLocalDateTime(utcDate);
-	if (!local) return formatDateTime(utcDate, options);
+	if (!local) return utcDate;
 	return new Date(local.year, local.month - 1, local.date, local.hours, local.minutes, local.seconds);
 }
 
 export function formatDateTimeFromTimestamp(timestamp, options) {
-	const localDate = parseLocalDateTimeFromTimestamp(timestamp, options);
-	return formatDateTime(localDate, options);
+	const date = parseLocalDateTimeFromTimestamp(timestamp);
+	return formatDateTime(date, options);
 }
 
 export function formatDateFromTimestamp(timestamp, options) {
-	const localDate = parseLocalDateTimeFromTimestamp(timestamp, options);
-	return formatDate(localDate, options);
+	const date = parseLocalDateTimeFromTimestamp(timestamp);
+	return formatDate(date, options);
 }
 
 export function formatTimeFromTimestamp(timestamp, options) {
-	const localDate = parseLocalDateTimeFromTimestamp(timestamp, options);
-	return formatTime(localDate, options);
+	const date = parseLocalDateTimeFromTimestamp(timestamp);
+	return formatTime(date, options);
 }

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -1128,10 +1128,24 @@ export function formatDateTime(date, options) {
 
 }
 
-export function formatDateTimeFromTimestamp(timestamp, options) {
+function parseLocalDateTimeFromTimestamp(timestamp, options) {
 	const utcDate = new Date(timestamp);
 	const local = convertJsDateToLocalDateTime(utcDate);
 	if (!local) return formatDateTime(utcDate, options);
-	const localDate = new Date(local.year, local.month - 1, local.date, local.hours, local.minutes, local.seconds);
+	return new Date(local.year, local.month - 1, local.date, local.hours, local.minutes, local.seconds);
+}
+
+export function formatDateTimeFromTimestamp(timestamp, options) {
+	const localDate = parseLocalDateTimeFromTimestamp(timestamp, options);
 	return formatDateTime(localDate, options);
+}
+
+export function formatDateFromTimestamp(timestamp, options) {
+	const localDate = parseLocalDateTimeFromTimestamp(timestamp, options);
+	return formatDate(localDate, options);
+}
+
+export function formatTimeFromTimestamp(timestamp, options) {
+	const localDate = parseLocalDateTimeFromTimestamp(timestamp, options);
+	return formatTime(localDate, options);
 }

--- a/test/dateTime.js
+++ b/test/dateTime.js
@@ -5,6 +5,8 @@ import {
 	formatDate,
 	formatDateTime,
 	formatDateTimeFromTimestamp,
+	formatDateFromTimestamp,
+	formatTimeFromTimestamp,
 	formatTime,
 	parseDate,
 	parseTime
@@ -889,4 +891,87 @@ describe('dateTime', () => {
 		});
 	});
 
+	describe('formatDateFromTimestamp', () => {
+		const options = { format: 'medium' };
+		const timestamp = Date.UTC(2015, 7, 25, 12, 28, 0);
+
+		it('should return original date if timezone identifier is blank', () => {
+			documentLocaleSettings.timezone.identifier = '';
+			const result = formatDateFromTimestamp(timestamp, options);
+			expect(result).to.deep.equal(formatDate(new Date(timestamp), options));
+		});
+
+		it('should throw if timezone identifier is invalid', () => {
+			documentLocaleSettings.timezone.identifier = 'FAKE';
+			expect(() => {
+				formatDateFromTimestamp(timestamp);
+			}).to.throw();
+		});
+
+		it('should have expected GMT offset of -5 for timezone America/Toronto at midnight', () => {
+			documentLocaleSettings.timezone.identifier = 'America/Toronto';
+			const timestamp2 = Date.UTC(2015, 1, 27, 5, 0, 0);
+			const result = formatDateFromTimestamp(timestamp2);
+			expect(result).to.deep.equal(formatDate(new Date(2015, 1, 27, 0, 0, 0)));
+		});
+
+		[
+			{ timezone: 'Pacific/Rarotonga', expectedDate: new Date(2015, 7, 25, 2, 28) },
+			{ timezone: 'America/Yakutat', expectedDate: new Date(2015, 7, 25, 4, 28) },
+			{ timezone: 'America/Santa_Isabel', expectedDate: new Date(2015, 7, 25, 5, 28) },
+			{ timezone: 'America/Toronto', expectedDate: new Date(2015, 7, 25, 8, 28) },
+			{ timezone: 'Atlantic/Reykjavik', expectedDate: new Date(2015, 7, 25, 12, 28) },
+			{ timezone: 'Australia/Eucla', expectedDate: new Date(2015, 7, 25, 21, 13) },
+			{ timezone: 'Australia/Darwin', expectedDate: new Date(2015, 7, 25, 21, 58) },
+			{ timezone: 'Pacific/Apia', expectedDate: new Date(2015, 7, 26, 1, 28) }
+		].forEach((test) => {
+			it(`should produce date ${test.expectedDate} for timezone ${test.timezone}`, () => {
+				documentLocaleSettings.timezone.identifier = test.timezone;
+				const result = formatDateFromTimestamp(timestamp, options);
+				expect(result).to.deep.equal(formatDate(test.expectedDate, options));
+			});
+		});
+	});
+
+	describe('formatTimeFromTimestamp', () => {
+		const options = { format: 'medium' };
+		const timestamp = Date.UTC(2015, 7, 25, 12, 28, 0);
+
+		it('should return original date if timezone identifier is blank', () => {
+			documentLocaleSettings.timezone.identifier = '';
+			const result = formatTimeFromTimestamp(timestamp, options);
+			expect(result).to.deep.equal(formatTime(new Date(timestamp), options));
+		});
+
+		it('should throw if timezone identifier is invalid', () => {
+			documentLocaleSettings.timezone.identifier = 'FAKE';
+			expect(() => {
+				formatTimeFromTimestamp(timestamp);
+			}).to.throw();
+		});
+
+		it('should have expected GMT offset of -5 for timezone America/Toronto at midnight', () => {
+			documentLocaleSettings.timezone.identifier = 'America/Toronto';
+			const timestamp2 = Date.UTC(2015, 1, 27, 5, 0, 0);
+			const result = formatTimeFromTimestamp(timestamp2);
+			expect(result).to.deep.equal(formatTime(new Date(2015, 1, 27, 0, 0, 0)));
+		});
+
+		[
+			{ timezone: 'Pacific/Rarotonga', expectedDate: new Date(2015, 7, 25, 2, 28) },
+			{ timezone: 'America/Yakutat', expectedDate: new Date(2015, 7, 25, 4, 28) },
+			{ timezone: 'America/Santa_Isabel', expectedDate: new Date(2015, 7, 25, 5, 28) },
+			{ timezone: 'America/Toronto', expectedDate: new Date(2015, 7, 25, 8, 28) },
+			{ timezone: 'Atlantic/Reykjavik', expectedDate: new Date(2015, 7, 25, 12, 28) },
+			{ timezone: 'Australia/Eucla', expectedDate: new Date(2015, 7, 25, 21, 13) },
+			{ timezone: 'Australia/Darwin', expectedDate: new Date(2015, 7, 25, 21, 58) },
+			{ timezone: 'Pacific/Apia', expectedDate: new Date(2015, 7, 26, 1, 28) }
+		].forEach((test) => {
+			it(`should produce date ${test.expectedDate} for timezone ${test.timezone}`, () => {
+				documentLocaleSettings.timezone.identifier = test.timezone;
+				const result = formatTimeFromTimestamp(timestamp, options);
+				expect(result).to.deep.equal(formatTime(test.expectedDate, options));
+			});
+		});
+	});
 });


### PR DESCRIPTION
I would like to propose we add the following methods to the date time helpers:

1. `formatDateFromTimestamp`
2. `formatTimeFromTimestamp`

This seems consistent with the other formatting helpers which provide options for formatting the date or time individually and allows more flexibility for consumers using timestamps.

Another thought I had was to expose the `parseLocalDateTimeFromTimestamp` method and allow consumers to format the resulting `Date` object however they want. I'm not sure if that would be a preferable option in this case.