### PR TITLE
DE46356 - Update dateTime.js in Brightspace UI with updated Canadian/Ontarian French date formats

### DIFF
--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -884,7 +884,7 @@ export function getDateTimeDescriptor() {
 			firstDayOfWeek = 0;
 			break;
 		case 'fr-on':
-			dateFormats[0] = 'dddd\' le \'d MMMM yyyy'; 
+			dateFormats[0] = 'dddd\' le \'d MMMM yyyy';
 			dateFormats[1] = 'MMM d yyyy';
 			dateFormats[2] = 'yyyy-MM-dd';
 			firstDayOfWeek = 0;

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -788,7 +788,7 @@ export function getDateTimeDescriptor() {
 			];
 			break;
 		case 'fr':
-			dateFormats = ['dddd\' le \'d MMMM yyyy', 'd MMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
+			dateFormats = ['dddd d MMMM yyyy', 'd MMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
 			months = [
 				['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'],
 				['janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin', 'juil.', 'août', 'sept.', 'oct.', 'nov.', 'déc.']
@@ -877,11 +877,16 @@ export function getDateTimeDescriptor() {
 			dateFormats = ['dddd, d MMMM yyyy', 'dd MMMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
 			break;
 		case 'fr-ca':
-		case 'fr-on':
 			dateFormats[1] = 'MMM d yyyy';
 			dateFormats[2] = 'yyyy-MM-dd';
 			dateFormats[4] = 'MMMM d';
 			dateFormats[5] = 'MMM d';
+			firstDayOfWeek = 0;
+			break;
+		case 'fr-on':
+			dateFormats[0] = 'dddd\' le \'d MMMM yyyy'; 
+			dateFormats[1] = 'MMM d yyyy';
+			dateFormats[2] = 'yyyy-MM-dd';
 			firstDayOfWeek = 0;
 			break;
 		case 'zh-tw':


### PR DESCRIPTION
- Removing "le" from long date format of fr-ca and fr-fr ("le" remains in fr-on).
- Making other elements consistent with formats in `LOCALE_CULTURE`.