### PR TITLE
fix: reset should revert to initial value

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -93,6 +93,7 @@ class DocumentLocaleSettings {
 		this._observer = new MutationObserver(this._handleObserverChange.bind(this));
 		this._observer.observe(this._htmlElem, { attributes: true });
 		this.sync();
+		this._languageInitial = this._language;
 	}
 
 	get fallbackLanguage() { return this._fallbackLanguage; }
@@ -136,7 +137,7 @@ class DocumentLocaleSettings {
 	}
 
 	reset() {
-		this._language = null;
+		this._language = this._languageInitial;
 		this._fallbackLanguage = null;
 		this.overrides = {};
 		this.timezone = { name: '', identifier: '' };


### PR DESCRIPTION
I ran into this in core -- `reset()` is only ever called from tests and is intended to reset things back to "normal" in between tests that might manipulate the document's language settings so they're all starting from a consistent state. The issue is that if the page initially loads with a particular language, `reset()` actually sets it to `null`. This fixes that.