### PR TITLE
feat: add locale names

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,45 +1,29 @@
 export const defaultLocale = 'en';
-export const supportedBaseLocalesDetails = [
-	{ code: 'ar', name: 'العربية', nameEn: 'Arabic' },
-	{ code: 'cy', name: 'Cymraeg', nameEn: 'Welsh' },
-	{ code: 'da', name: 'Dansk', nameEn: 'Danish' },
-	{ code: 'de', name: 'Deutsch', nameEn: 'German' },
-	{ code: 'en', name: 'English', nameEn: 'English' },
-	{ code: 'es', name: 'Español', nameEn: 'Spanish' },
-	{ code: 'fr', name: 'Français', nameEn: 'French' },
-	{ code: 'hi', name: 'हिन्दी', nameEn: 'Hindi' },
-	{ code: 'ja', name: '日本語', nameEn: 'Japanese' },
-	{ code: 'ko', name: '한국어', nameEn: 'Korean' },
-	{ code: 'nl', name: 'Nederlands', nameEn: 'Dutch' },
-	{ code: 'pt', name: 'Português', nameEn: 'Portuguese' },
-	{ code: 'sv', name: 'Svenska', nameEn: 'Swedish' },
-	{ code: 'tr', name: 'Türkçe', nameEn: 'Turkish' },
-	{ code: 'zh', name: '中文', nameEn: 'Chinese' },
+export const supportedBaseLocales = ['ar', 'cy', 'da', 'de', 'en', 'es', 'fr', 'hi', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh'];
+export const supportedLocalesDetails = [
+	{ code: 'ar-sa', name: 'العربية' },
+	{ code: 'cy-gb', name: 'Cymraeg (Y Deyrnas Unedig)' },
+	{ code: 'da-dk', name: 'Dansk (danmark)' },
+	{ code: 'de-de', name: 'Deutsch (Deutschland)' },
+	{ code: 'en-ca', name: 'English (Canada)' },
+	{ code: 'en-gb', name: 'English (United Kingdom)' },
+	{ code: 'en-us', name: 'English (United States)' },
+	{ code: 'es-es', name: 'Español (España)' },
+	{ code: 'es-mx', name: 'Español (Latinoamérica)' },
+	{ code: 'fr-ca', name: 'Français (Canada)' },
+	{ code: 'fr-fr', name: 'Français (France)' },
+	{ code: 'fr-on', name: 'Français (Ontario)' },
+	{ code: 'hi-in', name: 'हिन्दी Hindi (India)' },
+	{ code: 'ja-jp', name: '日本語 (日本)' },
+	{ code: 'ko-kr', name: '한국어 (대한민국)' },
+	{ code: 'nl-nl', name: 'Nederlands (Nederland)' },
+	{ code: 'pt-br', name: 'Português (Brasil)' },
+	{ code: 'sv-se', name: 'Svenska (Sverige)' },
+	{ code: 'tr-tr', name: 'Türkçe (Türkiye)' },
+	{ code: 'zh-cn', name: '中文(中华人民共和国)' },
+	{ code: 'zh-tw', name: '中文(台灣)' }
 ];
-export const supportedBaseLocales = supportedBaseLocalesDetails.map((l) => l.code);
-export const supportedLocales = [
-	'ar-sa',
-	'cy-gb',
-	'da-dk',
-	'de-de',
-	'en-us',
-	'en-ca',
-	'en-gb',
-	'es-es',
-	'es-mx',
-	'fr-ca',
-	'fr-fr',
-	'fr-on',
-	'hi-in',
-	'ja-jp',
-	'ko-kr',
-	'nl-nl',
-	'pt-br',
-	'sv-se',
-	'tr-tr',
-	'zh-cn',
-	'zh-tw'
-];
+export const supportedLocales = supportedLocalesDetails.map((l) => l.code);
 
 function tryResolve(langTag) {
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,5 +1,22 @@
 export const defaultLocale = 'en';
-export const supportedBaseLocales = ['ar', 'cy', 'da', 'de', 'en', 'es', 'fr', 'hi', 'ja', 'ko', 'nl', 'pt', 'sv', 'tr', 'zh'];
+export const supportedBaseLocalesDetails = [
+	{ code: 'ar', name: 'العربية', nameEn: 'Arabic' },
+	{ code: 'cy', name: 'Cymraeg', nameEn: 'Welsh' },
+	{ code: 'da', name: 'Dansk', nameEn: 'Danish' },
+	{ code: 'de', name: 'Deutsch', nameEn: 'German' },
+	{ code: 'en', name: 'English', nameEn: 'English' },
+	{ code: 'es', name: 'Español', nameEn: 'Spanish' },
+	{ code: 'fr', name: 'Français', nameEn: 'French' },
+	{ code: 'hi', name: 'हिन्दी', nameEn: 'Hindi' },
+	{ code: 'ja', name: '日本語', nameEn: 'Japanese' },
+	{ code: 'ko', name: '한국어', nameEn: 'Korean' },
+	{ code: 'nl', name: 'Nederlands', nameEn: 'Dutch' },
+	{ code: 'pt', name: 'Português', nameEn: 'Portuguese' },
+	{ code: 'sv', name: 'Svenska', nameEn: 'Swedish' },
+	{ code: 'tr', name: 'Türkçe', nameEn: 'Turkish' },
+	{ code: 'zh', name: '中文', nameEn: 'Chinese' },
+];
+export const supportedBaseLocales = supportedBaseLocalesDetails.map((l) => l.code);
 export const supportedLocales = [
 	'ar-sa',
 	'cy-gb',


### PR DESCRIPTION
Exposing the localized locale names for our supported locales. This will make rendering a "language picker" dropdown easier.