### PR TITLE
feat: cache date/time descriptor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @BrightspaceUI/gaudi-dev

--- a/lib/common.js
+++ b/lib/common.js
@@ -88,6 +88,7 @@ export function validateFormatValue(value) {
 class DocumentLocaleSettings {
 
 	constructor() {
+		this._cache = new Map();
 		this._htmlElem = window.document.getElementsByTagName('html')[0];
 		this._listeners = [];
 		this._overrides = {};
@@ -101,6 +102,7 @@ class DocumentLocaleSettings {
 	set fallbackLanguage(val) {
 		const normalized = this._normalize(val);
 		if (normalized === this._fallbackLanguage) return;
+		this._cache.clear();
 		this._fallbackLanguage = normalized;
 		this._listeners.forEach((cb) => cb());
 	}
@@ -109,6 +111,7 @@ class DocumentLocaleSettings {
 	set language(val) {
 		const normalized = this._normalize(val);
 		if (normalized === this._language) return;
+		this._cache.clear();
 		this._language = normalized;
 		this._listeners.forEach((cb) => cb());
 	}
@@ -123,12 +126,20 @@ class DocumentLocaleSettings {
 				delete val.date.formats.timeFormats;
 			}
 		}
+		this._cache.clear();
 		this._overrides = val;
 		this._listeners.forEach((cb) => cb());
 	}
 
 	addChangeListener(cb) {
 		this._listeners.push(cb);
+	}
+
+	getCacheItem(key, provider) {
+		if (!this._cache.has(key)) {
+			this._cache.set(key, provider());
+		}
+		return this._cache.get(key);
 	}
 
 	removeChangeListener(cb) {
@@ -138,6 +149,7 @@ class DocumentLocaleSettings {
 	}
 
 	reset() {
+		this._cache.clear();
 		this._language = this._languageInitial;
 		this._fallbackLanguage = null;
 		this.overrides = {};

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -691,266 +691,267 @@ export function convertUTCToLocalDateTime(date) {
 }
 
 export function getDateTimeDescriptor() {
-
-	const language = getLanguage();
 	const settings = getDocumentLocaleSettings();
+	return settings.getCacheItem('dateTimeDescriptor', () => {
 
-	const subtags = language.split('-');
-	const baseLanguage = subtags[0];
+		const language = getLanguage();
+		const subtags = language.split('-');
+		const baseLanguage = subtags[0];
 
-	let hour24 = (hour24locales.indexOf(baseLanguage) > -1);
-	if (language === 'zh-tw') {
-		hour24 = false;
-	}
-	if (settings.overrides.date && settings.overrides.date.hour24 !== undefined) {
-		hour24 = settings.overrides.date.hour24;
-	}
-
-	const timeFormat = getTimeFormat(hour24, language, baseLanguage);
-
-	let dateFormats = ['dddd, MMMM d, yyyy', 'MMM d, yyyy', 'M/d/yyyy', 'MMMM yyyy', 'MMMM d', 'MMM d'];
-	const fullTimeFormat = (baseLanguage === 'zh' && language !== 'zh-tw') ? `ZZZ ${timeFormat}` : `${timeFormat} ZZZ`;
-	let dayPeriods = ['AM', 'PM'];
-	let months = [
-		['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-		['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-	];
-	let days = [
-		['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-		['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-		['S', 'M', 'T', 'W', 'T', 'F', 'S']
-	];
-	let firstDayOfWeek = (mondayFirstDayLocales.indexOf(baseLanguage) > -1) ? 1 : 0;
-	let weekendStartDay = 6;
-	let weekendEndDay = 0;
-
-	switch (baseLanguage) {
-		case 'ar':
-			dateFormats = ['dddd, d MMMM, yyyy', 'dd MMMM, yyyy', 'dd/MM/yyyy', 'MMMM, yyyy', 'd MMMM', 'd MMM'];
-			dayPeriods = ['ص', 'م'];
-			months[0] = months[1] = ['يناير', 'فبراير', 'مارس', 'أبريل', 'مايو', 'يونيو', 'يوليو', 'أغسطس', 'سبتمبر', 'أكتوبر', 'نوفمبر', 'ديسمبر'];
-			days = [
-				['الأحد', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
-				['أحد', 'إثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت'],
-				['أ', 'إ', 'ث', 'أر', 'خ', 'ج', 'س']
-			];
-			firstDayOfWeek = 6;
-			weekendStartDay = 4;
-			weekendEndDay = 5;
-			break;
-		case 'cy':
-			dateFormats = ['dddd, d MMMM yyyy', 'dd MMMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
-			months = [
-				['Ionawr', 'Chwefror', 'Mawrth', 'Ebrill', 'Mai', 'Mehefin', 'Gorffennaf', 'Awst', 'Medi', 'Hydref', 'Tachwedd', 'Rhagfyr'],
-				['Ion', 'Chwe', 'Maw', 'Ebr', 'Mai', 'Meh', 'Gor', 'Awst', 'Medi', 'Hyd', 'Tach', 'Rhag']
-			];
-			days = [
-				['Dydd Sul', 'Dydd Llun', 'Dydd Mawrth', 'Dydd Mercher', 'Dydd Iau', 'Dydd Gwener', 'Dydd Sadwrn'],
-				['Sul', 'Llun', 'Maw', 'Mer', 'Iau', 'Gwe', 'Sad'],
-				['Su', 'Ll', 'Ma', 'Me', 'Ia', 'Gw', 'Sa']
-			];
-			break;
-		case 'da':
-			dateFormats = ['dddd \'den\' d. MMMM yyyy', 'd. MMM. yyyy', 'dd.MM.yyyy', 'MMMM yyyy', 'd. MMMM', 'd. MMM'];
-			months = [
-				['januar', 'februar', 'marts', 'april', 'maj', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'december'],
-				['jan.', 'feb.', 'mar.', 'apr.', 'maj', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.']
-			];
-			days = [
-				['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'],
-				['søn.', 'man.', 'tir.', 'ons.', 'tor.', 'fre.', 'lør.'],
-				['S', 'M', 'T', 'O', 'T', 'F', 'L']
-			];
-			break;
-		case 'de':
-			dateFormats = ['dddd d. MMMM yyyy', 'd. MMMM yyyy', 'dd.MM.yyyy', 'MMMM yyyy', 'd. MMMM', 'd. MMM'];
-			months = [
-				['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
-				['Jan.', 'Feb.', 'März', 'Apr.', 'Mai', 'Juni', 'Juli', 'Aug.', 'Sept.', 'Okt.', 'Nov.', 'Dez.']
-			];
-			days = [
-				['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-				['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
-				['S', 'M', 'D', 'M', 'D', 'F', 'S']
-			];
-			break;
-		case 'es':
-			dateFormats = ['dddd d\' de \'MMMM\' de \'yyyy', 'd\' de \'MMMM\' de \'yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd\' de \'MMMM', 'd\' de \'MMM'];
-			dayPeriods = ['a. m.', 'p. m.'];
-			months = [
-				['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'],
-				['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.']
-			];
-			days = [
-				['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
-				['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],
-				['D', 'L', 'M', 'M', 'J', 'V', 'S']
-			];
-			break;
-		case 'fr':
-			dateFormats = ['dddd d MMMM yyyy', 'd MMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
-			months = [
-				['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'],
-				['janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin', 'juil.', 'août', 'sept.', 'oct.', 'nov.', 'déc.']
-			];
-			days = [
-				['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'],
-				['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
-				['D', 'L', 'M', 'M', 'J', 'V', 'S']
-			];
-			break;
-		case 'hi':
-			dateFormats = ['dddd, d MMMM yyyy', 'd MMMM yyyy', 'dd-MM-yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
-			dayPeriods = ['पूर्वाह्न', 'अपराह्न'];
-			months = [
-				['जनवरी', 'फरवरी', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अगस्त', 'सितंबर', 'अक्टूबर', 'नवंबर', 'दिसंबर'],
-				['जन', 'फर', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अग', 'सितं', 'अक्टू', 'नवं', 'दिसं']
-			];
-			days = [
-				['रविवार', 'सोमवार', 'मंगलवार', 'बुधवार', 'गुरूवार', 'शुक्रवार', 'शनिवार'],
-				['रवि', 'सोम', 'मंगल', 'बुध', 'गुरु', 'शुक्र', 'शनि'],
-				['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श']
-			];
-			break;
-		case 'ja':
-			dateFormats = ['yyyy年M月d日', 'yyyy年M月d日', 'yyyy/MM/dd', 'yyyy年M月', 'M月d日', 'M月d日'];
-			dayPeriods = ['午前', '午後'];
-			months[0] = months[1] = ['1 月', '2 月', '3 月', '4 月', '5 月', '6 月', '7 月', '8 月', '9 月', '10 月', '11 月', '12 月'];
-			days[0] = days[1] = days[2] = ['日', '月', '火', '水', '木', '金', '土'];
-			break;
-		case 'ko':
-			dateFormats = ['yyyy년 M월 d일 dddd', 'yyyy년 M월 d일', 'yyyy-MM-dd', 'yyyy년 M월', 'M월 d일', 'MMM d일'];
-			dayPeriods = ['오전', '오후'];
-			months[0] = months[1] = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
-			days[0] = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
-			days[1] = days[2] = ['일', '월', '화', '수', '목', '금', '토'];
-			break;
-		case 'nl':
-			dateFormats = ['dddd d MMMM yyyy', 'd MMMM yyyy', 'dd-MM-yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
-			dayPeriods = ['a.m.', 'p.m.'];
-			months = [
-				['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
-				['jan.', 'feb.', 'mrt.', 'apr.', 'mei', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.']
-			];
-			days = [
-				['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
-				['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
-				['Z', 'M', 'D', 'W', 'D', 'V', 'Z']
-			];
-			break;
-		case 'pt':
-			dateFormats = ['dddd, d\' de \'MMMM\' de \'yyyy', 'd\' de  \'MMMM\' de \'yyyy', 'dd/MM/yyyy', 'MMMM\' de \'yyyy', 'dd\' de \'MMMM', 'dd\' de \'MMM'];
-			months = [
-				['janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho', 'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro'],
-				['jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez']
-			];
-			days = [
-				['domingo', 'segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado'],
-				['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'],
-				['D', 'S', 'T', 'Q', 'Q', 'S', 'S']
-			];
-			break;
-		case 'sv':
-			dateFormats = ['dddd \'den\' d MMMM yyyy', 'd MMMM yyyy', 'yyyy-MM-dd', 'MMMM yyyy', 'dd MMMM', 'dd MMM'];
-			dayPeriods = ['fm', 'em'];
-			months = [
-				['januari', 'februari', 'mars', 'april', 'maj', 'juni', 'juli', 'augusti', 'september', 'oktober', 'november', 'december'],
-				['jan.', 'feb.', 'mars', 'apr.', 'maj', 'juni', 'juli', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.']
-			];
-			days = [
-				['Söndag', 'Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag'],
-				['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör'],
-				['S', 'M', 'T', 'O', 'T', 'F', 'L']
-			];
-			break;
-		case 'tr':
-			dateFormats = ['dd MMMM yyyy dddd', 'dd MMMM yyyy', 'dd.MM.yyyy', 'MMMM yyyy', 'dd MMMM', 'dd MMM'];
-			dayPeriods = ['ÖÖ', 'ÖS'];
-			months = [
-				['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık'],
-				['Oca', 'Şub', 'Mar', 'Nis', 'May', 'Haz', 'Tem', 'Ağu', 'Eyl', 'Ek', 'Kas', 'Ara']
-			];
-			days = [
-				['Pazar', 'Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi'],
-				['Paz', 'Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt'],
-				['P', 'P', 'S', 'Ç', 'P', 'C', 'C']
-			];
-			break;
-		case 'zh':
-			dateFormats = ['yyyy年M月d日', 'yyyy年M月d日', 'yyyy/M/d', 'yyyy年M月', 'M月d日', 'M月d日'];
-			dayPeriods = ['上午', '下午'];
-			months[0] = months[1] = ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'];
-			days[0] = days[1] = ['週日', '週一', '週二', '週三', '週四', '週五', '週六'];
-			days[2] = ['日', '一', '二', '三', '四', '五', '六'];
-			break;
-	}
-
-	switch (language) {
-		case 'en-gb':
-			dateFormats = ['dddd, d MMMM yyyy', 'dd MMMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
-			break;
-		case 'fr-ca':
-			dateFormats[1] = 'MMM d yyyy';
-			dateFormats[2] = 'yyyy-MM-dd';
-			dateFormats[4] = 'MMMM d';
-			dateFormats[5] = 'MMM d';
-			firstDayOfWeek = 0;
-			break;
-		case 'fr-on':
-			dateFormats[0] = 'dddd\' le \'d MMMM yyyy';
-			dateFormats[1] = 'MMM d yyyy';
-			dateFormats[2] = 'yyyy-MM-dd';
-			firstDayOfWeek = 0;
-			break;
-		case 'zh-tw':
-			days[0] = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'];
-			break;
-	}
-
-	const descriptor = {
-		hour24: hour24,
-		formats: {
-			dateFormats: {
-				'full': dateFormats[0],
-				'medium': dateFormats[1],
-				'short': dateFormats[2],
-				'monthYear': dateFormats[3],
-				'monthDay': dateFormats[4],
-				'shortMonthDay': dateFormats[5],
-				'longDayOfWeek': 'dddd',
-				'shortDayOfWeek': 'ddd',
-				'longMonth': 'MMMM',
-				'shortMonth': 'MMM'
-			},
-			timeFormats: {
-				'full': fullTimeFormat,
-				'medium': timeFormat,
-				'short': timeFormat
-			}
-		},
-		calendar: {
-			firstDayOfWeek: firstDayOfWeek,
-			weekendStartDay: weekendStartDay,
-			weekendEndDay: weekendEndDay,
-			months: {
-				short: months[1],
-				long: months[0]
-			},
-			days: {
-				narrow: days[2],
-				short: days[1],
-				long: days[0]
-			},
-			dayPeriods: { am: dayPeriods[0], pm: dayPeriods[1] }
+		let hour24 = (hour24locales.indexOf(baseLanguage) > -1);
+		if (language === 'zh-tw') {
+			hour24 = false;
 		}
-	};
+		if (settings.overrides.date && settings.overrides.date.hour24 !== undefined) {
+			hour24 = settings.overrides.date.hour24;
+		}
 
-	if (settings.overrides.date) {
-		merge(descriptor, settings.overrides.date);
-	}
+		const timeFormat = getTimeFormat(hour24, language, baseLanguage);
 
-	return descriptor;
+		let dateFormats = ['dddd, MMMM d, yyyy', 'MMM d, yyyy', 'M/d/yyyy', 'MMMM yyyy', 'MMMM d', 'MMM d'];
+		const fullTimeFormat = (baseLanguage === 'zh' && language !== 'zh-tw') ? `ZZZ ${timeFormat}` : `${timeFormat} ZZZ`;
+		let dayPeriods = ['AM', 'PM'];
+		let months = [
+			['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+			['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+		];
+		let days = [
+			['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+			['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+			['S', 'M', 'T', 'W', 'T', 'F', 'S']
+		];
+		let firstDayOfWeek = (mondayFirstDayLocales.indexOf(baseLanguage) > -1) ? 1 : 0;
+		let weekendStartDay = 6;
+		let weekendEndDay = 0;
 
+		switch (baseLanguage) {
+			case 'ar':
+				dateFormats = ['dddd, d MMMM, yyyy', 'dd MMMM, yyyy', 'dd/MM/yyyy', 'MMMM, yyyy', 'd MMMM', 'd MMM'];
+				dayPeriods = ['ص', 'م'];
+				months[0] = months[1] = ['يناير', 'فبراير', 'مارس', 'أبريل', 'مايو', 'يونيو', 'يوليو', 'أغسطس', 'سبتمبر', 'أكتوبر', 'نوفمبر', 'ديسمبر'];
+				days = [
+					['الأحد', 'الإثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+					['أحد', 'إثنين', 'ثلاثاء', 'أربعاء', 'خميس', 'جمعة', 'سبت'],
+					['أ', 'إ', 'ث', 'أر', 'خ', 'ج', 'س']
+				];
+				firstDayOfWeek = 6;
+				weekendStartDay = 4;
+				weekendEndDay = 5;
+				break;
+			case 'cy':
+				dateFormats = ['dddd, d MMMM yyyy', 'dd MMMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
+				months = [
+					['Ionawr', 'Chwefror', 'Mawrth', 'Ebrill', 'Mai', 'Mehefin', 'Gorffennaf', 'Awst', 'Medi', 'Hydref', 'Tachwedd', 'Rhagfyr'],
+					['Ion', 'Chwe', 'Maw', 'Ebr', 'Mai', 'Meh', 'Gor', 'Awst', 'Medi', 'Hyd', 'Tach', 'Rhag']
+				];
+				days = [
+					['Dydd Sul', 'Dydd Llun', 'Dydd Mawrth', 'Dydd Mercher', 'Dydd Iau', 'Dydd Gwener', 'Dydd Sadwrn'],
+					['Sul', 'Llun', 'Maw', 'Mer', 'Iau', 'Gwe', 'Sad'],
+					['Su', 'Ll', 'Ma', 'Me', 'Ia', 'Gw', 'Sa']
+				];
+				break;
+			case 'da':
+				dateFormats = ['dddd \'den\' d. MMMM yyyy', 'd. MMM. yyyy', 'dd.MM.yyyy', 'MMMM yyyy', 'd. MMMM', 'd. MMM'];
+				months = [
+					['januar', 'februar', 'marts', 'april', 'maj', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'december'],
+					['jan.', 'feb.', 'mar.', 'apr.', 'maj', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.']
+				];
+				days = [
+					['søndag', 'mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag'],
+					['søn.', 'man.', 'tir.', 'ons.', 'tor.', 'fre.', 'lør.'],
+					['S', 'M', 'T', 'O', 'T', 'F', 'L']
+				];
+				break;
+			case 'de':
+				dateFormats = ['dddd d. MMMM yyyy', 'd. MMMM yyyy', 'dd.MM.yyyy', 'MMMM yyyy', 'd. MMMM', 'd. MMM'];
+				months = [
+					['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
+					['Jan.', 'Feb.', 'März', 'Apr.', 'Mai', 'Juni', 'Juli', 'Aug.', 'Sept.', 'Okt.', 'Nov.', 'Dez.']
+				];
+				days = [
+					['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
+					['So.', 'Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.'],
+					['S', 'M', 'D', 'M', 'D', 'F', 'S']
+				];
+				break;
+			case 'es':
+				dateFormats = ['dddd d\' de \'MMMM\' de \'yyyy', 'd\' de \'MMMM\' de \'yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd\' de \'MMMM', 'd\' de \'MMM'];
+				dayPeriods = ['a. m.', 'p. m.'];
+				months = [
+					['enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre'],
+					['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.']
+				];
+				days = [
+					['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'],
+					['dom.', 'lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.'],
+					['D', 'L', 'M', 'M', 'J', 'V', 'S']
+				];
+				break;
+			case 'fr':
+				dateFormats = ['dddd d MMMM yyyy', 'd MMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
+				months = [
+					['janvier', 'février', 'mars', 'avril', 'mai', 'juin', 'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre'],
+					['janv.', 'févr.', 'mars', 'avr.', 'mai', 'juin', 'juil.', 'août', 'sept.', 'oct.', 'nov.', 'déc.']
+				];
+				days = [
+					['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'],
+					['dim.', 'lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.'],
+					['D', 'L', 'M', 'M', 'J', 'V', 'S']
+				];
+				break;
+			case 'hi':
+				dateFormats = ['dddd, d MMMM yyyy', 'd MMMM yyyy', 'dd-MM-yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
+				dayPeriods = ['पूर्वाह्न', 'अपराह्न'];
+				months = [
+					['जनवरी', 'फरवरी', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अगस्त', 'सितंबर', 'अक्टूबर', 'नवंबर', 'दिसंबर'],
+					['जन', 'फर', 'मार्च', 'अप्रैल', 'मई', 'जून', 'जुलाई', 'अग', 'सितं', 'अक्टू', 'नवं', 'दिसं']
+				];
+				days = [
+					['रविवार', 'सोमवार', 'मंगलवार', 'बुधवार', 'गुरूवार', 'शुक्रवार', 'शनिवार'],
+					['रवि', 'सोम', 'मंगल', 'बुध', 'गुरु', 'शुक्र', 'शनि'],
+					['र', 'सो', 'मं', 'बु', 'गु', 'शु', 'श']
+				];
+				break;
+			case 'ja':
+				dateFormats = ['yyyy年M月d日', 'yyyy年M月d日', 'yyyy/MM/dd', 'yyyy年M月', 'M月d日', 'M月d日'];
+				dayPeriods = ['午前', '午後'];
+				months[0] = months[1] = ['1 月', '2 月', '3 月', '4 月', '5 月', '6 月', '7 月', '8 月', '9 月', '10 月', '11 月', '12 月'];
+				days[0] = days[1] = days[2] = ['日', '月', '火', '水', '木', '金', '土'];
+				break;
+			case 'ko':
+				dateFormats = ['yyyy년 M월 d일 dddd', 'yyyy년 M월 d일', 'yyyy-MM-dd', 'yyyy년 M월', 'M월 d일', 'MMM d일'];
+				dayPeriods = ['오전', '오후'];
+				months[0] = months[1] = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', '9월', '10월', '11월', '12월'];
+				days[0] = ['일요일', '월요일', '화요일', '수요일', '목요일', '금요일', '토요일'];
+				days[1] = days[2] = ['일', '월', '화', '수', '목', '금', '토'];
+				break;
+			case 'nl':
+				dateFormats = ['dddd d MMMM yyyy', 'd MMMM yyyy', 'dd-MM-yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
+				dayPeriods = ['a.m.', 'p.m.'];
+				months = [
+					['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
+					['jan.', 'feb.', 'mrt.', 'apr.', 'mei', 'jun.', 'jul.', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.']
+				];
+				days = [
+					['zondag', 'maandag', 'dinsdag', 'woensdag', 'donderdag', 'vrijdag', 'zaterdag'],
+					['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za'],
+					['Z', 'M', 'D', 'W', 'D', 'V', 'Z']
+				];
+				break;
+			case 'pt':
+				dateFormats = ['dddd, d\' de \'MMMM\' de \'yyyy', 'd\' de  \'MMMM\' de \'yyyy', 'dd/MM/yyyy', 'MMMM\' de \'yyyy', 'dd\' de \'MMMM', 'dd\' de \'MMM'];
+				months = [
+					['janeiro', 'fevereiro', 'março', 'abril', 'maio', 'junho', 'julho', 'agosto', 'setembro', 'outubro', 'novembro', 'dezembro'],
+					['jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez']
+				];
+				days = [
+					['domingo', 'segunda-feira', 'terça-feira', 'quarta-feira', 'quinta-feira', 'sexta-feira', 'sábado'],
+					['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'],
+					['D', 'S', 'T', 'Q', 'Q', 'S', 'S']
+				];
+				break;
+			case 'sv':
+				dateFormats = ['dddd \'den\' d MMMM yyyy', 'd MMMM yyyy', 'yyyy-MM-dd', 'MMMM yyyy', 'dd MMMM', 'dd MMM'];
+				dayPeriods = ['fm', 'em'];
+				months = [
+					['januari', 'februari', 'mars', 'april', 'maj', 'juni', 'juli', 'augusti', 'september', 'oktober', 'november', 'december'],
+					['jan.', 'feb.', 'mars', 'apr.', 'maj', 'juni', 'juli', 'aug.', 'sep.', 'okt.', 'nov.', 'dec.']
+				];
+				days = [
+					['Söndag', 'Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag'],
+					['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör'],
+					['S', 'M', 'T', 'O', 'T', 'F', 'L']
+				];
+				break;
+			case 'tr':
+				dateFormats = ['dd MMMM yyyy dddd', 'dd MMMM yyyy', 'dd.MM.yyyy', 'MMMM yyyy', 'dd MMMM', 'dd MMM'];
+				dayPeriods = ['ÖÖ', 'ÖS'];
+				months = [
+					['Ocak', 'Şubat', 'Mart', 'Nisan', 'Mayıs', 'Haziran', 'Temmuz', 'Ağustos', 'Eylül', 'Ekim', 'Kasım', 'Aralık'],
+					['Oca', 'Şub', 'Mar', 'Nis', 'May', 'Haz', 'Tem', 'Ağu', 'Eyl', 'Ek', 'Kas', 'Ara']
+				];
+				days = [
+					['Pazar', 'Pazartesi', 'Salı', 'Çarşamba', 'Perşembe', 'Cuma', 'Cumartesi'],
+					['Paz', 'Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt'],
+					['P', 'P', 'S', 'Ç', 'P', 'C', 'C']
+				];
+				break;
+			case 'zh':
+				dateFormats = ['yyyy年M月d日', 'yyyy年M月d日', 'yyyy/M/d', 'yyyy年M月', 'M月d日', 'M月d日'];
+				dayPeriods = ['上午', '下午'];
+				months[0] = months[1] = ['一月', '二月', '三月', '四月', '五月', '六月', '七月', '八月', '九月', '十月', '十一月', '十二月'];
+				days[0] = days[1] = ['週日', '週一', '週二', '週三', '週四', '週五', '週六'];
+				days[2] = ['日', '一', '二', '三', '四', '五', '六'];
+				break;
+		}
+
+		switch (language) {
+			case 'en-gb':
+				dateFormats = ['dddd, d MMMM yyyy', 'dd MMMM yyyy', 'dd/MM/yyyy', 'MMMM yyyy', 'd MMMM', 'd MMM'];
+				break;
+			case 'fr-ca':
+				dateFormats[1] = 'MMM d yyyy';
+				dateFormats[2] = 'yyyy-MM-dd';
+				dateFormats[4] = 'MMMM d';
+				dateFormats[5] = 'MMM d';
+				firstDayOfWeek = 0;
+				break;
+			case 'fr-on':
+				dateFormats[0] = 'dddd\' le \'d MMMM yyyy';
+				dateFormats[1] = 'MMM d yyyy';
+				dateFormats[2] = 'yyyy-MM-dd';
+				firstDayOfWeek = 0;
+				break;
+			case 'zh-tw':
+				days[0] = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'];
+				break;
+		}
+
+		const descriptor = {
+			hour24: hour24,
+			formats: {
+				dateFormats: {
+					'full': dateFormats[0],
+					'medium': dateFormats[1],
+					'short': dateFormats[2],
+					'monthYear': dateFormats[3],
+					'monthDay': dateFormats[4],
+					'shortMonthDay': dateFormats[5],
+					'longDayOfWeek': 'dddd',
+					'shortDayOfWeek': 'ddd',
+					'longMonth': 'MMMM',
+					'shortMonth': 'MMM'
+				},
+				timeFormats: {
+					'full': fullTimeFormat,
+					'medium': timeFormat,
+					'short': timeFormat
+				}
+			},
+			calendar: {
+				firstDayOfWeek: firstDayOfWeek,
+				weekendStartDay: weekendStartDay,
+				weekendEndDay: weekendEndDay,
+				months: {
+					short: months[1],
+					long: months[0]
+				},
+				days: {
+					narrow: days[2],
+					short: days[1],
+					long: days[0]
+				},
+				dayPeriods: { am: dayPeriods[0], pm: dayPeriods[1] }
+			}
+		};
+
+		if (settings.overrides.date) {
+			merge(descriptor, settings.overrides.date);
+		}
+
+		return descriptor;
+
+	});
 }
 
 export function formatTime(date, options) {

--- a/test/common.js
+++ b/test/common.js
@@ -294,4 +294,46 @@ describe('common', () => {
 
 	});
 
+	describe('cache', () => {
+
+		let called;
+		const provider = () => {
+			called++;
+			return 'foo';
+		};
+
+		beforeEach(() => called = 0);
+
+		it('should call provider to get value', () => {
+			const value = documentLocaleSettings.getCacheItem('key', provider);
+			expect(value).to.equal('foo');
+			expect(called).to.equal(1);
+		});
+
+		it('should only call provider once', () => {
+			const val1 = documentLocaleSettings.getCacheItem('key', provider);
+			const val2 = documentLocaleSettings.getCacheItem('key', provider);
+			expect(val1).to.equal('foo');
+			expect(val2).to.equal('foo');
+			expect(called).to.equal(1);
+		});
+
+		['language', 'fallbackLanguage', 'overrides'].forEach(prop => {
+			it(`should invalidate cache when ${prop} is set`, () => {
+				documentLocaleSettings.getCacheItem('key', provider);
+				documentLocaleSettings[prop] = 'zz';
+				documentLocaleSettings.getCacheItem('key', provider);
+				expect(called).to.equal(2);
+			});
+		});
+
+		it('should invalidate cache when reset is called', () => {
+			documentLocaleSettings.getCacheItem('key', provider);
+			documentLocaleSettings.reset();
+			documentLocaleSettings.getCacheItem('key', provider);
+			expect(called).to.equal(2);
+		});
+
+	});
+
 });


### PR DESCRIPTION
We're [removing core's cache](https://github.com/BrightspaceUI/core/pull/3986) of the date/time descriptor because it had no way to know when to invalidate it when the language changed.

This re-adds the caching in a better place -- at the source!