### PR TITLE
Add type to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.15.0",
   "description": "Internationalization APIs for number, date, time and file size formatting and parsing in D2L Brightspace.",
   "main": "lib/number.js",
+  "type": "module",
   "scripts": {
     "lint": "eslint . --ext .js",
     "start": "web-dev-server --node-resolve --watch --open /demo/",


### PR DESCRIPTION
There are some edge cases where imports from this library fail because it thinks it's a commonJS module. Frankly, I'm not sure why there hasn't been more issues without this declared.