### PR TITLE
fix: align with LMS naming

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -22,8 +22,8 @@ export const supportedLocalesDetails = [
 	{ code: 'pt-br', name: 'Português (Brasil)' },
 	{ code: 'sv-se', name: 'Svenska (Sverige)' },
 	{ code: 'tr-tr', name: 'Türkçe (Türkiye)' },
-	{ code: 'zh-cn', name: '中文(中华人民共和国)' },
-	{ code: 'zh-tw', name: '中文(台灣)' }
+	{ code: 'zh-cn', name: '中文(简体)' },
+	{ code: 'zh-tw', name: '中文(繁体)' }
 ];
 export const supportedLocales = supportedLocalesDetails.map((l) => l.code);
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -2,7 +2,7 @@ export const defaultLocale = 'en';
 export const supportedBaseLocales = ['ar', 'cy', 'da', 'de', 'en', 'es', 'fr', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh'];
 export const supportedLangpacks = ['ar', 'cy', 'da', 'de', 'en', 'en-gb', 'es', 'es-es', 'fr', 'fr-fr', 'fr-on', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh-cn', 'zh-tw'];
 export const supportedLocalesDetails = [
-	{ code: 'ar-sa', name: 'العربية' },
+	{ code: 'ar-sa', name: 'العربية (المملكة العربية السعودية)' },
 	{ code: 'cy-gb', name: 'Cymraeg (Y Deyrnas Unedig)' },
 	{ code: 'da-dk', name: 'Dansk (danmark)' },
 	{ code: 'de-de', name: 'Deutsch (Deutschland)' },
@@ -14,7 +14,7 @@ export const supportedLocalesDetails = [
 	{ code: 'fr-ca', name: 'Français (Canada)' },
 	{ code: 'fr-fr', name: 'Français (France)' },
 	{ code: 'fr-on', name: 'Français (Ontario)' },
-	{ code: 'hi-in', name: 'हिन्दी Hindi (India)' },
+	{ code: 'hi-in', name: 'हिंदी (भारत)' },
 	{ code: 'ja-jp', name: '日本語 (日本)' },
 	{ code: 'ko-kr', name: '한국어 (대한민국)' },
 	{ code: 'mi-nz', name: 'Māori (Aotearoa)' },


### PR DESCRIPTION
This is to align things with what's in `LANG_LANGUAGES` in the LMS.