### PR TITLE
fix: update release timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: Release
-    timeout-minutes: 2
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The previous release timed out because it took too long to add comments to all the PRs that were included (mostly Dependabot).  It didn't end up publishing to NPM.