### PR TITLE
Add PluralRules locale data shimming

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,3 @@ updates:
       # update-package-lock workflow already handles minor/patch updates
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-      - dependency-name: "@formatjs/intl-pluralrules"

--- a/lib/PluralRules.js
+++ b/lib/PluralRules.js
@@ -49,7 +49,7 @@ class PluralRules extends Intl.PluralRules {
 
 	constructor(locales, options = {}) {
 		super(locales, options);
-		this.#locale = PluralRules.supportedLocalesOf(getCanonicalLocales(locales))[0];
+		this.#locale = PluralRules.supportedLocalesOf(locales)[0];
 		this.#type = options.type ?? 'cardinal';
 		if (localeData[this.#locale]) {
 			this.#localeData = localeData[this.#locale];

--- a/lib/PluralRules.js
+++ b/lib/PluralRules.js
@@ -1,0 +1,70 @@
+//import '@formatjs/intl-pluralrules/polyfill.js';
+
+const customLocales = ['mi'];
+
+const originalPluralRules = Intl.PluralRules;
+
+/*
+function PluralRules(locale) {
+  if (typeof locale === 'string' && customLocales.includes(Intl.getCanonicalLocales(locale))) {
+
+  } else {
+    reutrn originalPluralRules(...arguments)
+  }
+}
+*/
+
+const localeData = {
+	mi: {
+		cardinal: {
+			locale: 'mi',
+			pluralCategories : [ 'one', 'other' ],
+		},
+		ordinal: {
+			locale: 'mi',
+			pluralCategories : [ 'other' ],
+		},
+		select(n, ord) {
+			return !ord && n === 1 ? 'one' : 'other';
+		}
+	}
+};
+
+class PluralRules extends Intl.PluralRules {
+
+	#localeData;
+	#locale;
+	#type;
+
+	constructor(locales, options = {}) {
+		super();
+		this.#locale = Intl.getCanonicalLocales(locales)[0];
+		this.#type = options.type ?? 'cardinal';
+		if (customLocales.includes(this.#locale)) {
+			this.#localeData = localeData[this.#locale];
+		}
+	}
+
+	resolvedOptions() {
+		return { ...super.resolvedOptions(), ...this.#localeData[this.#type] };
+	}
+
+	select(n) {
+		if (this.#localeData) {
+			return localeData[this.#locale].select(n, this.#type === 'ordinal');
+		} else {
+			return super.select(n);
+		}
+	}
+}
+
+Object.defineProperty(Intl, 'PluralRules', {
+	value: PluralRules,
+	writable: true,
+	enumerable: false,
+	configurable: true,
+});
+
+console.log(new Intl.PluralRules('mi', { type: 'ordinal' }).resolvedOptions());
+console.log(new Intl.PluralRules('mi', { type: 'cardinal' }).resolvedOptions());
+console.log(new Intl.PluralRules('en', { type: 'cardinal' }).resolvedOptions());

--- a/lib/PluralRules.js
+++ b/lib/PluralRules.js
@@ -1,28 +1,15 @@
-//import '@formatjs/intl-pluralrules/polyfill.js';
-
-const customLocales = ['mi'];
-
-const originalPluralRules = Intl.PluralRules;
-
-/*
-function PluralRules(locale) {
-  if (typeof locale === 'string' && customLocales.includes(Intl.getCanonicalLocales(locale))) {
-
-  } else {
-    reutrn originalPluralRules(...arguments)
-  }
-}
-*/
-
 const localeData = {
 	mi: {
+    aliases: ['mri', 'mao'],
 		cardinal: {
 			locale: 'mi',
 			pluralCategories : [ 'one', 'other' ],
+      shim: true
 		},
 		ordinal: {
 			locale: 'mi',
 			pluralCategories : [ 'other' ],
+      shim: true
 		},
 		select(n, ord) {
 			return !ord && n === 1 ? 'one' : 'other';
@@ -30,23 +17,36 @@ const localeData = {
 	}
 };
 
+function getCanonicalLocales(locales) {
+  const mappedLocales = [locales].flat().map(locale => {
+    for (const canonicalLocale in localeData) {
+      if (localeData[canonicalLocale].aliases.includes(locale)) {
+        return canonicalLocale;
+      }
+    }
+    return locale;
+  });
+  return Intl.getCanonicalLocales(mappedLocales);
+}
+
 class PluralRules extends Intl.PluralRules {
 
+  static shim = true;
 	#localeData;
 	#locale;
 	#type;
 
 	constructor(locales, options = {}) {
-		super();
-		this.#locale = Intl.getCanonicalLocales(locales)[0];
+		super(locales, options);
+		this.#locale = PluralRules.supportedLocalesOf(getCanonicalLocales(locales))[0];
 		this.#type = options.type ?? 'cardinal';
-		if (customLocales.includes(this.#locale)) {
+		if (localeData[this.#locale]) {
 			this.#localeData = localeData[this.#locale];
 		}
 	}
 
 	resolvedOptions() {
-		return { ...super.resolvedOptions(), ...this.#localeData[this.#type] };
+		return { ...super.resolvedOptions(), ...this.#localeData?.[this.#type] };
 	}
 
 	select(n) {
@@ -56,6 +56,16 @@ class PluralRules extends Intl.PluralRules {
 			return super.select(n);
 		}
 	}
+
+  static supportedLocalesOf(locales) {
+    return [locales].flat().map(l => {
+      const canonicalLocale = getCanonicalLocales(l)[0];
+      if (localeData[canonicalLocale]) {
+        return canonicalLocale;
+      }
+      return super.supportedLocalesOf(l);
+    }).flat();
+  }
 }
 
 Object.defineProperty(Intl, 'PluralRules', {
@@ -64,7 +74,3 @@ Object.defineProperty(Intl, 'PluralRules', {
 	enumerable: false,
 	configurable: true,
 });
-
-console.log(new Intl.PluralRules('mi', { type: 'ordinal' }).resolvedOptions());
-console.log(new Intl.PluralRules('mi', { type: 'cardinal' }).resolvedOptions());
-console.log(new Intl.PluralRules('en', { type: 'cardinal' }).resolvedOptions());

--- a/lib/PluralRules.js
+++ b/lib/PluralRules.js
@@ -1,15 +1,15 @@
 const localeData = {
 	mi: {
-    aliases: ['mri', 'mao'],
+		aliases: ['mri', 'mao'],
 		cardinal: {
 			locale: 'mi',
 			pluralCategories : [ 'one', 'other' ],
-      shim: true
+			shim: true
 		},
 		ordinal: {
 			locale: 'mi',
 			pluralCategories : [ 'other' ],
-      shim: true
+			shim: true
 		},
 		select(n, ord) {
 			return !ord && n === 1 ? 'one' : 'other';
@@ -18,20 +18,29 @@ const localeData = {
 };
 
 function getCanonicalLocales(locales) {
-  const mappedLocales = [locales].flat().map(locale => {
-    for (const canonicalLocale in localeData) {
-      if (localeData[canonicalLocale].aliases.includes(locale)) {
-        return canonicalLocale;
-      }
-    }
-    return locale;
-  });
-  return Intl.getCanonicalLocales(mappedLocales);
+	const mappedLocales = [locales].flat().map(locale => {
+		for (const canonicalLocale in localeData) {
+			if (localeData[canonicalLocale].aliases.includes(locale)) {
+				return canonicalLocale;
+			}
+		}
+		return locale;
+	});
+	return Intl.getCanonicalLocales(mappedLocales);
 }
 
 class PluralRules extends Intl.PluralRules {
 
-  static shim = true;
+	static shim = true;
+	static supportedLocalesOf(locales) {
+		return [locales].flat().map(l => {
+			const canonicalLocale = getCanonicalLocales(l)[0];
+			if (localeData[canonicalLocale]) {
+				return canonicalLocale;
+			}
+			return super.supportedLocalesOf(l);
+		}).flat();
+	}
 	#localeData;
 	#locale;
 	#type;
@@ -57,15 +66,6 @@ class PluralRules extends Intl.PluralRules {
 		}
 	}
 
-  static supportedLocalesOf(locales) {
-    return [locales].flat().map(l => {
-      const canonicalLocale = getCanonicalLocales(l)[0];
-      if (localeData[canonicalLocale]) {
-        return canonicalLocale;
-      }
-      return super.supportedLocalesOf(l);
-    }).flat();
-  }
 }
 
 Object.defineProperty(Intl, 'PluralRules', {

--- a/lib/PluralRules.js
+++ b/lib/PluralRules.js
@@ -1,15 +1,17 @@
 const localeData = {
 	mi: {
 		aliases: ['mri', 'mao'],
-		cardinal: {
-			locale: 'mi',
-			pluralCategories : [ 'one', 'other' ],
-			shim: true
-		},
-		ordinal: {
-			locale: 'mi',
-			pluralCategories : [ 'other' ],
-			shim: true
+		options: {
+			cardinal: {
+				locale: 'mi',
+				pluralCategories : [ 'one', 'other' ],
+				shim: true
+			},
+			ordinal: {
+				locale: 'mi',
+				pluralCategories : [ 'other' ],
+				shim: true
+			},
 		},
 		select(n, ord) {
 			return !ord && n === 1 ? 'one' : 'other';
@@ -55,12 +57,12 @@ class PluralRules extends Intl.PluralRules {
 	}
 
 	resolvedOptions() {
-		return { ...super.resolvedOptions(), ...this.#localeData?.[this.#type] };
+		return { ...super.resolvedOptions(), ...this.#localeData?.options[this.#type] };
 	}
 
 	select(n) {
 		if (this.#localeData) {
-			return localeData[this.#locale].select(n, this.#type === 'ordinal');
+			return this.#localeData.select(n, this.#type === 'ordinal');
 		} else {
 			return super.select(n);
 		}

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -1,4 +1,5 @@
-import { defaultLocale as fallbackLang, getDocumentLocaleSettings, supportedLangpacks } from '../lib/common.js';
+import './PluralRules.js';
+import { defaultLocale as fallbackLang, getDocumentLocaleSettings, supportedLangpacks } from './common.js';
 import { getLocalizeOverrideResources } from '../helpers/getLocalizeResources.js';
 import IntlMessageFormat from 'intl-messageformat';
 

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -1,4 +1,3 @@
-import '@formatjs/intl-pluralrules/dist-es6/polyfill-locales.js';
 import { defaultLocale as fallbackLang, getDocumentLocaleSettings, supportedLangpacks } from '../lib/common.js';
 import { getLocalizeOverrideResources } from '../helpers/getLocalizeResources.js';
 import IntlMessageFormat from 'intl-messageformat';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.18.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@formatjs/intl-pluralrules": "^1",
         "intl-messageformat": "^10"
       },
       "devDependencies": {
@@ -583,6 +582,7 @@
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-1.5.9.tgz",
       "integrity": "sha512-37E1ZG+Oqo3qrpUfumzNcFTV+V+NCExmTkkQ9Zw4FSlvJ4WhbbeYdieVapUVz9M0cLy8XrhCkfuM/Kn03iKReg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@formatjs/intl-utils": "^2.3.0"
@@ -593,6 +593,7 @@
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz",
       "integrity": "sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==",
       "deprecated": "the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@hapi/bourne": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "sinon": "^19.0.2"
   },
   "dependencies": {
-    "@formatjs/intl-pluralrules": "^1",
     "intl-messageformat": "^10"
   }
 }

--- a/test/PluralRules.test.js
+++ b/test/PluralRules.test.js
@@ -19,6 +19,7 @@ describe('PluralRules', () => {
 		const shim = new Intl.PluralRules('cy');
 		const native = new (Object.getPrototypeOf(Intl.PluralRules))('cy');
 		expect(shim.resolvedOptions()).to.deep.equal(native.resolvedOptions());
+		expect(shim.select(2)).to.equal('two');
 	});
 
 	it('resolves to canonical locales', () => {

--- a/test/PluralRules.test.js
+++ b/test/PluralRules.test.js
@@ -1,0 +1,22 @@
+import { expect } from '@brightspace-ui/testing';
+import { getDocumentLocaleSettings } from '../lib/common.js';
+import { getSeparator } from '../lib/PluralRules.js';
+
+describe('PluralRules', () => {
+
+	const documentLocaleSettings = getDocumentLocaleSettings();
+
+	afterEach(() => documentLocaleSettings.reset());
+
+	[
+		{ locale: 'mi', type: 'cardinal', expect: { categories: [ 'one', 'other' ] } },
+		{ locale: 'mi', type: 'ordinal', expect: { categories: [ 'other' ] } }
+	].forEach(({ locale, type, expect }) => {
+		it(`should use custom data for "${locale}"`, () => {
+			documentLocaleSettings.language = locale;
+			const pluralRules = new Intl.PluralRules(locale, { type });
+			expect(pluralRules).to.have.deeo.properties(expect);
+		});
+	});
+
+});

--- a/test/PluralRules.test.js
+++ b/test/PluralRules.test.js
@@ -1,6 +1,6 @@
+import '../lib/PluralRules.js';
 import { expect } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '../lib/common.js';
-import { getSeparator } from '../lib/PluralRules.js';
 
 describe('PluralRules', () => {
 
@@ -8,14 +8,70 @@ describe('PluralRules', () => {
 
 	afterEach(() => documentLocaleSettings.reset());
 
+	it('extends native Intl.PluralRules', () => {
+		const native = Object.getPrototypeOf(Intl.PluralRules);
+		expect(Intl.PluralRules.shim).to.be.true;
+		expect(native).to.have.property('name', 'PluralRules');
+		expect(native).to.not.have.property('shim');
+	});
+
+	it('uses native data by default', () => {
+		const shim = new Intl.PluralRules('cy');
+		const native = new (Object.getPrototypeOf(Intl.PluralRules))('cy');
+		expect(shim.resolvedOptions()).to.deep.equal(native.resolvedOptions());
+	});
+
+	it('resolves to canonical locales', () => {
+		expect(new Intl.PluralRules('mao').resolvedOptions().locale).to.equal('mi');
+		expect(new Intl.PluralRules('mri').resolvedOptions().locale).to.equal('mi');
+		expect(new Intl.PluralRules(['abcdefg', 'mri']).resolvedOptions().locale).to.equal('mi');
+	});
+
+	it('includes custom locales as supported', () => {
+		expect(Intl.PluralRules.supportedLocalesOf(['abc', 'mao', 'en'])).to.deep.equal(['mi', 'en']);
+	});
+
 	[
-		{ locale: 'mi', type: 'cardinal', expect: { categories: [ 'one', 'other' ] } },
-		{ locale: 'mi', type: 'ordinal', expect: { categories: [ 'other' ] } }
-	].forEach(({ locale, type, expect }) => {
-		it(`should use custom data for "${locale}"`, () => {
-			documentLocaleSettings.language = locale;
-			const pluralRules = new Intl.PluralRules(locale, { type });
-			expect(pluralRules).to.have.deeo.properties(expect);
+		{
+			locale: 'mi',
+			type: 'cardinal',
+			options: {
+				locale: 'mi',
+				shim: true,
+				pluralCategories: [ 'one', 'other' ]
+			},
+			select: {
+				one: [1],
+				other: [0, 2, 3, 11]
+			}
+		},
+		{
+			locale: 'mi',
+			type: 'ordinal',
+			options: {
+				locale: 'mi',
+				shim: true,
+				pluralCategories: [ 'other' ]
+			},
+			select: {
+				other: [0, 1, 2, 3, 11]
+			}
+		}
+	].forEach(({ locale, type, options, select }) => {
+
+		documentLocaleSettings.language = locale;
+		const pluralRules = new Intl.PluralRules(locale, { type });
+
+		it(`should use custom ${type} data for "${locale}"`, () => {
+			expect(pluralRules.resolvedOptions()).to.deep.include(options);
+		});
+
+		it(`should select the correct ${type} number categories for "${locale}"`, () => {
+			options.pluralCategories.forEach(cat => {
+				select[cat].forEach(num => {
+					expect(pluralRules.select(num)).to.equal(cat);
+				});
+			});
 		});
 	});
 

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -9,6 +9,10 @@ const resources = {
 	},
 	'en-gb': {
 		basic: '{employerName} is my employer, but British!'
+	},
+	mi: {
+		plural: '{a, plural, one {one} other {other}}',
+		ordinal: '{a, selectordinal, one {one} other {other}}'
 	}
 };
 
@@ -77,6 +81,24 @@ describe('Localize', () => {
 			await localizer.ready;
 			const localized = localizer.localize('many', 'type', 'message', 'count', 2);
 			expect(localized).to.equal('This message has 2 arguments');
+		});
+
+		it('should select the correct category for shimmed locales', async() => {
+			await localizer.ready;
+			document.documentElement.lang = 'mi';
+			await updatePromise;
+
+			const pluralOne = localizer.localize('plural', { a: 1 });
+			expect(pluralOne).to.equal('one');
+
+			const pluralTwo = localizer.localize('plural', { a: 2 });
+			expect(pluralTwo).to.equal('other');
+
+			const ordinalOne = localizer.localize('ordinal', { a: 1 });
+			expect(ordinalOne).to.equal('other');
+
+			const ordinalTwo = localizer.localize('ordinal', { a: 2 });
+			expect(ordinalTwo).to.equal('other');
 		});
 
 	});


### PR DESCRIPTION
Support for Māori across browsers is inconsistent at best. Specifically for `Intl.PluralRules` (which is relied upon by `formatjs` to render `plural` arguments), no browsers have (proper) native support for Māori's plural categories. The `@formatjs/intl-pluralrules` polyfill also does not have data for Māori, and provides no value otherwise as `Intl.PluralRules` is well supported at this point.

We can rely on native `Intl.PluralRules` as long as we can shim locale data into it for `formatjs` to use. So, that's what we do here.

