### PR TITLE
feat: add ability to localize common characters

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,11 @@
     "rules": {
       "no-console": 0
     }
-  }]
+  },
+  {
+		"files": "./lang/*.js",
+		"rules": {
+			"quotes": 0
+		}
+	}]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,9 +13,9 @@
     }
   },
   {
-		"files": "./lang/*.js",
-		"rules": {
-			"quotes": 0
-		}
-	}]
+    "files": "./lang/*.js",
+    "rules": {
+      "quotes": 0
+    }
+  }]
 }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-This library consists of APIs to format and parse numbers, dates, times and file sizes for use in D2L Brightspace.
+This library consists of APIs to format and parse numbers, dates, times and file sizes for use in D2L Brightspace. It also provides localization for common terms.
 
 > Looking for the older `d2l-intl` library? It's still here [in the `v2.x` branch](https://github.com/BrightspaceUI/intl/tree/v2.x).
 
@@ -28,7 +28,9 @@ import { formatNumber, formatPercent } from '@brightspace-ui/intl/lib/number.js'
 
 All of the APIs will automatically detect the document's language via the `lang` attribute on the `<html>` element. They'll also look for various `data-` attributes that will be present in Brightspace pages to access override and timezone information.
 
-## Number Formatting
+## Numbers
+
+### Number Formatting
 
 Integer and decimal numbers can be formatted in the user's locale using `formatNumber`. Percentages can be formatted using `formatPercent`. Use the optional `options` parameter for rounding.
 
@@ -65,7 +67,7 @@ const value = formatPercent(0.333, {
 }); // -> '33.30 %' in en-US
 ```
 
-## Number Parsing
+### Number Parsing
 
 The `parseNumber` method can be used to parse an integer or decimal number written in the user's locale.
 
@@ -75,7 +77,9 @@ import { parseNumber } from '@brightspace-ui/intl/lib/number.js';
 const value = parseNumber('-8 942,39'); // -> -8942.39 in fr-CA
 ```
 
-## Date/Time Formatting
+## Dates & Times
+
+### Date & Time Formatting
 
 Dates and times can be formatted in the user's locale using `formatDate`, `formatTime`, `formatDateTime`, and `formatRelativeDateTime`.
 
@@ -183,7 +187,7 @@ const relativeDateTime = formatRelativeDateTime(
 ); // If today is 2024-08-22, -> 'last week' in en-US
 ```
 
-## Date Parsing
+### Date Parsing
 
 To parse a date written in the user's locale, use `parseDate`:
 
@@ -196,7 +200,7 @@ date.getMonth(); // -> 8 (months are 0-11)
 date.getDate(); // -> 23
 ```
 
-## Time Parsing
+### Time Parsing
 
 To parse a time written in the user's locale, use `parseTime`:
 
@@ -208,7 +212,7 @@ date.getHours(); // -> 14
 date.getMinutes(); // -> 5
 ```
 
-## Date/Time Conversion based on user timezone
+### Date/Time Conversion based on user timezone
 
 To convert an object containing a UTC date to an object containing a local date corresponding to the `data-timezone` attribute:
 ```javascript
@@ -372,7 +376,41 @@ In addition to the Basic Formatting elements, these additional elements may also
 * `<d2l-link>`
 * `<d2l-tooltip-help>`
 
+### Common Resources
+
+Some localization resources are common and shared across D2L applications. To use these resources, set the `loadCommon` option:
+
+```javascript
+import { Localize } from '@brightspace-ui/intl/lib/localize.js';
+
+const localizer = new Localize({
+  loadCommon: true
+});
+```
+
+#### localizeCharacter
+
+The localized value of the following characters can be accessed using `localizeCharacter(char)`:
+* `'` (apostrophe)
+* `&` (ampersand)
+* `*` (asterisk)
+* `\` (backslash)
+* `:` (colon)
+* `,` (comma)
+* `>` (greater-than sign)
+* `<` (less-than sign)
+* `#` (number sign)
+* `%` (percent sign)
+* `|` (pipe)
+* `?` (question mark)
+* `"` (quotation mark)
+
+```javascript
+const value = localizer.localizeCharacter('&'); // -> 'ampersand' in en-US
+```
+
 ### `onResourcesChange`
+
 Provide an `onResourcesChange` callback function to perform tasks when the document language is changed and updated resources are available:
 
 ```javascript

--- a/intl.serge.json
+++ b/intl.serge.json
@@ -1,0 +1,9 @@
+{
+	"name": "intl",
+	"parser_plugin": {
+	  "plugin": "parse_js"
+	},
+	"source_match": "en\\.js$",
+	"source_dir": "lang",
+	"output_file_path": "lang/%LANG%.js"
+  }

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/da.js
+++ b/lang/da.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/de.js
+++ b/lang/de.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,15 +1,15 @@
 export default {
-	"intl-common:characters:apostrophe": "apostrophe", // description of the "'" character
-	"intl-common:characters:ampersand": "ampersand", // description of the "&" character
-	"intl-common:characters:asterisk": "asterisk", // description of the "*" character
-	"intl-common:characters:backslash": "backslash", // description of the "\" character
-	"intl-common:characters:colon": "colon", // description of the ":" character
-	"intl-common:characters:comma": "comma", // description of the "," character
-	"intl-common:characters:greaterThan": "greater-than sign", // description of the ">" character
-	"intl-common:characters:lessThan": "less-than sign", // description of the "<" character
-	"intl-common:characters:numberSign": "number sign", // description of the "#" character
-	"intl-common:characters:percentSign": "percent sign", // description of the "%" character
-	"intl-common:characters:pipe": "pipe", // description of the "|" character
-	"intl-common:characters:questionMark": "question mark", // description of the "?" character
-	"intl-common:characters:quotationMark": "quotation mark", // description of the '"' character
+	"intl-common:characters:apostrophe": "apostrophe", // short name or description of the "'" character
+	"intl-common:characters:ampersand": "ampersand", // short name or description of the "&" character
+	"intl-common:characters:asterisk": "asterisk", // short name or description of the "*" character
+	"intl-common:characters:backslash": "backslash", // short name or description of the "\" character
+	"intl-common:characters:colon": "colon", // short name or description of the ":" character
+	"intl-common:characters:comma": "comma", // short name or description of the "," character
+	"intl-common:characters:greaterThan": "greater-than sign", // short name or description of the ">" character
+	"intl-common:characters:lessThan": "less-than sign", // short name or description of the "<" character
+	"intl-common:characters:numberSign": "number sign", // short name or description of the "#" character
+	"intl-common:characters:percentSign": "percent sign", // short name or description of the "%" character
+	"intl-common:characters:pipe": "pipe", // short name or description of the "|" character
+	"intl-common:characters:questionMark": "question mark", // short name or description of the "?" character
+	"intl-common:characters:quotationMark": "quotation mark", // short name or description of the '"' character
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,15 +1,15 @@
 export default {
-	"intl-common:characters:apostrophe": "apostrophe",
-	"intl-common:characters:ampersand": "ampersand",
-	"intl-common:characters:asterisk": "asterisk",
-	"intl-common:characters:backslash": "backslash",
-	"intl-common:characters:colon": "colon",
-	"intl-common:characters:comma": "comma",
-	"intl-common:characters:greaterThan": "greater-than sign",
-	"intl-common:characters:lessThan": "less-than sign",
-	"intl-common:characters:numberSign": "number sign",
-	"intl-common:characters:percentSign": "percent sign",
-	"intl-common:characters:pipe": "pipe",
-	"intl-common:characters:questionMark": "question mark",
-	"intl-common:characters:quotationMark": "quotation mark",
+	"intl-common:characters:apostrophe": "apostrophe", // description of the "'" character
+	"intl-common:characters:ampersand": "ampersand", // description of the "&" character
+	"intl-common:characters:asterisk": "asterisk", // description of the "*" character
+	"intl-common:characters:backslash": "backslash", // description of the "\" character
+	"intl-common:characters:colon": "colon", // description of the ":" character
+	"intl-common:characters:comma": "comma", // description of the "," character
+	"intl-common:characters:greaterThan": "greater-than sign", // description of the ">" character
+	"intl-common:characters:lessThan": "less-than sign", // description of the "<" character
+	"intl-common:characters:numberSign": "number sign", // description of the "#" character
+	"intl-common:characters:percentSign": "percent sign", // description of the "%" character
+	"intl-common:characters:pipe": "pipe", // description of the "|" character
+	"intl-common:characters:questionMark": "question mark", // description of the "?" character
+	"intl-common:characters:quotationMark": "quotation mark", // description of the '"' character
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/es.js
+++ b/lang/es.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -1,0 +1,15 @@
+export default {
+	"intl-common:characters:apostrophe": "apostrophe",
+	"intl-common:characters:ampersand": "ampersand",
+	"intl-common:characters:asterisk": "asterisk",
+	"intl-common:characters:backslash": "backslash",
+	"intl-common:characters:colon": "colon",
+	"intl-common:characters:comma": "comma",
+	"intl-common:characters:greaterThan": "greater-than sign",
+	"intl-common:characters:lessThan": "less-than sign",
+	"intl-common:characters:numberSign": "number sign",
+	"intl-common:characters:percentSign": "percent sign",
+	"intl-common:characters:pipe": "pipe",
+	"intl-common:characters:questionMark": "question mark",
+	"intl-common:characters:quotationMark": "quotation mark",
+};

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -88,7 +88,11 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 		if (!characterMap.has(char)) {
 			throw new Error(`localizeCharacter() does not support character: "${char}"`);
 		}
-		return this.localize(`intl-common:characters:${characterMap.get(char)}`);
+		const value = this.localize(`intl-common:characters:${characterMap.get(char)}`);
+		if (value.length === 0) {
+			throw new Error('localizeCharacter() cannot be used unless loadCommon in localizeConfig is enabled');
+		}
+		return value;
 	}
 
 	localizeHTML(name, replacements = {}) {
@@ -150,11 +154,15 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 		}
 		if (Object.prototype.hasOwnProperty.call(this, 'getLocalizeResources') || Object.prototype.hasOwnProperty.call(this, 'resources')) {
 			const possibleLanguages = this._generatePossibleLanguages(config);
-			const resourcesPromise = this.getLocalizeResources(possibleLanguages, config);
-			resourcesLoadedPromises.push(resourcesPromise);
-			resourcesLoadedPromises.push(this.getLocalizeResources(possibleLanguages, {
-				importFunc: async lang => (await import(`../lang/${lang}.js`)).default
-			}));
+			if (config?.importFunc) {
+				const resourcesPromise = this.getLocalizeResources(possibleLanguages, config);
+				resourcesLoadedPromises.push(resourcesPromise);
+			}
+			if (config?.loadCommon) {
+				resourcesLoadedPromises.push(this.getLocalizeResources(possibleLanguages, {
+					importFunc: async lang => (await import(`../lang/${lang}.js`)).default
+				}));
+			}
 		}
 		return Promise.all(resourcesLoadedPromises);
 	}

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -20,6 +20,8 @@ const characterMap = new Map([
 	['?', 'questionMark'],
 	['"', 'quotationMark']
 ]);
+const commonResources = new Map();
+export let commonResourcesImportCount = 0;
 
 const getDisallowedTagsRegex = allowedTags => {
 	const validTerminators = '([>\\s/]|$)';
@@ -160,7 +162,13 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 			}
 			if (config?.loadCommon) {
 				resourcesLoadedPromises.push(this.getLocalizeResources(possibleLanguages, {
-					importFunc: async lang => (await import(`../lang/${lang}.js`)).default
+					importFunc: async(lang) => {
+						if (commonResources.has(lang)) return commonResources.get(lang);
+						const resources = (await import(`../lang/${lang}.js`)).default;
+						commonResourcesImportCount++;
+						commonResources.set(lang, resources);
+						return resources;
+					}
 				}));
 			}
 		}

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -5,6 +5,22 @@ import IntlMessageFormat from 'intl-messageformat';
 
 export const allowedTags = Object.freeze(['d2l-link', 'd2l-tooltip-help', 'p', 'br', 'b', 'strong', 'i', 'em', 'button']);
 
+const characterMap = new Map([
+	['\'', 'apostrophe'],
+	['&', 'ampersand'],
+	['*', 'asterisk'],
+	['\\', 'backslash'],
+	[':', 'colon'],
+	[',', 'comma'],
+	['>', 'greaterThan'],
+	['<', 'lessThan'],
+	['#', 'numberSign'],
+	['%', 'percentSign'],
+	['|', 'pipe'],
+	['?', 'questionMark'],
+	['"', 'quotationMark']
+]);
+
 const getDisallowedTagsRegex = allowedTags => {
 	const validTerminators = '([>\\s/]|$)';
 	const allowedAfterTriangleBracket = `/?(${allowedTags.join('|')})?${validTerminators}`;
@@ -68,6 +84,13 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 		return formattedMessage;
 	}
 
+	localizeCharacter(char) {
+		if (!characterMap.has(char)) {
+			throw new Error(`localizeCharacter() does not support character: "${char}"`);
+		}
+		return this.localize(`intl-common:characters:${characterMap.get(char)}`);
+	}
+
 	localizeHTML(name, replacements = {}) {
 
 		const { language, value } = this.localize.resources?.[name] ?? {};
@@ -129,6 +152,9 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 			const possibleLanguages = this._generatePossibleLanguages(config);
 			const resourcesPromise = this.getLocalizeResources(possibleLanguages, config);
 			resourcesLoadedPromises.push(resourcesPromise);
+			resourcesLoadedPromises.push(this.getLocalizeResources(possibleLanguages, {
+				importFunc: async lang => (await import(`../lang/${lang}.js`)).default
+			}));
 		}
 		return Promise.all(resourcesLoadedPromises);
 	}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "npm run lint && npm run test:unit"
   },
   "files": [
+    "/lang",
     "/lib",
     "/helpers"
   ],

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -1,5 +1,5 @@
-import { expect, fixture } from '@brightspace-ui/testing';
 import { commonResourcesImportCount, Localize, localizeMarkup } from '../lib/localize.js';
+import { expect, fixture } from '@brightspace-ui/testing';
 
 const resources = {
 	en: {

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -118,18 +118,36 @@ describe('Localize', () => {
 
 	});
 
-	describe('localizeCharacter', () => {
+	describe('common', () => {
 
-		it('should localize "&"', async() => {
-			await localizer.ready;
-			const localized = localizer.localizeCharacter('&');
-			expect(localized).to.equal('ampersand');
+		let localizerCommon;
+		beforeEach(async() => {
+			localizerCommon = new Localize({
+				loadCommon: true
+			});
+			await localizerCommon.ready;
 		});
 
-		it('should throw an error for unknown characters', async() => {
-			await localizer.ready;
-			expect(() => localizer.localizeCharacter('$'))
-				.to.throw('localizeCharacter() does not support character: "$"');
+		afterEach(() => localizerCommon.disconnect());
+
+		describe('localizeCharacter', () => {
+
+			it('should localize "&"', async() => {
+				const localized = localizerCommon.localizeCharacter('&');
+				expect(localized).to.equal('ampersand');
+			});
+
+			it('should throw an error for unknown characters', async() => {
+				expect(() => localizerCommon.localizeCharacter('$'))
+					.to.throw('localizeCharacter() does not support character: "$"');
+			});
+
+			it('should throw an error if common resources are not loaded', async() => {
+				await localizer.ready;
+				expect(() => localizerCommon.localizeCharacter(':'))
+					.to.throw('localizeCharacter() cannot be used unless loadCommon in localizeConfig is enabled');
+			});
+
 		});
 
 	});

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -1,5 +1,5 @@
 import { expect, fixture } from '@brightspace-ui/testing';
-import { Localize, localizeMarkup } from '../lib/localize.js';
+import { commonResourcesImportCount, Localize, localizeMarkup } from '../lib/localize.js';
 
 const resources = {
 	en: {
@@ -129,6 +129,15 @@ describe('Localize', () => {
 		});
 
 		afterEach(() => localizerCommon.disconnect());
+
+		it('should only load common resources once', async() => {
+			const localizer1 = new Localize({ loadCommon: true });
+			const localizer2 = new Localize({ loadCommon: true });
+			await Promise.all([localizer1.ready, localizer2.ready]);
+			expect(commonResourcesImportCount).to.equal(1);
+			localizer1.disconnect();
+			localizer2.disconnect();
+		});
 
 		describe('localizeCharacter', () => {
 

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -153,7 +153,7 @@ describe('Localize', () => {
 
 			it('should throw an error if common resources are not loaded', async() => {
 				await localizer.ready;
-				expect(() => localizerCommon.localizeCharacter(':'))
+				expect(() => localizer.localizeCharacter(':'))
 					.to.throw('localizeCharacter() cannot be used unless loadCommon in localizeConfig is enabled');
 			});
 

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -118,6 +118,22 @@ describe('Localize', () => {
 
 	});
 
+	describe('localizeCharacter', () => {
+
+		it('should localize "&"', async() => {
+			await localizer.ready;
+			const localized = localizer.localizeCharacter('&');
+			expect(localized).to.equal('ampersand');
+		});
+
+		it('should throw an error for unknown characters', async() => {
+			await localizer.ready;
+			expect(() => localizer.localizeCharacter('$'))
+				.to.throw('localizeCharacter() does not support character: "$"');
+		});
+
+	});
+
 	describe('localizeHTML()', () => {
 
 		it('should localize, replacing tags with HTML', async() => {


### PR DESCRIPTION
I had some trouble figuring out how best to integrate this, so definitely interested in feedback and other ideas.

The big downside to this approach is that every component that wires up to a localizer via the `LocalizeMixin` is going to have these "common" terms merged into their collection. That's why I needed to use the `intl-common` prefix on all their keys to avoid a potential collission.

~It also means that the common terms will **always** be fetched once on every page, even if they're not used. Both `localize` and `localizeHTML` are synchronous, so I couldn't think of a way to defer the loading of the common stuff.~ That's no longer true now that `loadCommon: true` must be set in the config.