### PR TITLE
Create instance own localize method

### DIFF
--- a/lib/localize.js
+++ b/lib/localize.js
@@ -214,6 +214,7 @@ export const Localize = class extends getLocalizeClass() {
 	constructor(config) {
 		super();
 		super.constructor.setLocalizeMarkup(localizeMarkup);
+		this.localize = (...args) => super.localize(...args);
 		this.config = config;
 		this.connect();
 	}


### PR DESCRIPTION
Each instance of the `Localize` class should have its own (as in `hasOwn`) `localize` method to store its resources and other localization-related state.

This is not applied to the `LocalizeClass` so that other uses, like for component mixins, can continue to share resources per-component. There is some light additional work to be done in `core` to fully take advantage of this because it's currently re-fetching for each element even if the component has its resources. However, that can be done separately from this change.

Using [`getPrototypeOf`/`super` instead of `bind`](https://jsbenchmark.com/#eyJjYXNlcyI6W3siaWQiOiI1am9KT00zUENlQXdFUTkzRms5RVgiLCJjb2RlIjoiREFUQS5iLmIoKTsiLCJuYW1lIjoiRmluZCA5OSIsImRlcGVuZGVuY2llcyI6W119LHsiaWQiOiJkXzBjTEVYZUh6aTFhdHJqdnpFRHciLCJjb2RlIjoiREFUQS5jLmIoKTsiLCJuYW1lIjoiRmluZCAxOTkiLCJkZXBlbmRlbmNpZXMiOltdfV0sImNvbmZpZyI6eyJuYW1lIjoiQmFzaWMgZXhhbXBsZSIsInBhcmFsbGVsIjp0cnVlLCJnbG9iYWxUZXN0Q29uZmlnIjp7ImRlcGVuZGVuY2llcyI6W119LCJkYXRhQ29kZSI6ImNsYXNzIEEge1xuICBiKCkge1xuICAgIHJldHVybiAxO1xuICB9XG59XG5cbmNsYXNzIEIgZXh0ZW5kcyBBIHtcbiAgYiA9IHRoaXMuYi5iaW5kKHRoaXMpO1xufVxuXG5jbGFzcyBDIGV4dGVuZHMgQSB7XG4gIGIgPSAoKSA9PiBPYmplY3QuZ2V0UHJvdG90eXBlT2YodGhpcykuYigpO1xufVxuXG5yZXR1cm4geyBiOiBuZXcgQigpLCBjOiBuZXcgQygpIH07In19) has the advantage of keeping the shared `localize` method and not hogging memory, with no hit to speed.