### PR TITLE
fix: if loadCommon then there are resources

### DIFF
--- a/lib/localize.js
+++ b/lib/localize.js
@@ -205,7 +205,11 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 	}
 
 	_hasResources() {
-		return this.constructor.localizeConfig ? Boolean(this.constructor.localizeConfig.importFunc) : this.constructor.getLocalizeResources !== undefined;
+		if (this.constructor.localizeConfig) {
+			return this.constructor.localizeConfig !== undefined ||
+				this.constructor.localizeConfig.loadCommon === true;
+		}
+		return this.constructor.getLocalizeResources !== undefined;
 	}
 
 	async #localeChangeHandler() {


### PR DESCRIPTION
Small tweak to this after trying to consume if from core in a component using `LocalizeMixin`. `LocalizeMixin` checks the value of `_hasResources` to defer rendering until the resources have loaded.