### PR TITLE
Add Hawaiian to supported languages

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,6 +1,6 @@
 export const defaultLocale = 'en';
-export const supportedBaseLocales = ['ar', 'cy', 'da', 'de', 'en', 'es', 'fr', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh'];
-export const supportedLangpacks = ['ar', 'cy', 'da', 'de', 'en', 'en-gb', 'es', 'es-es', 'fr', 'fr-fr', 'fr-on', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh-cn', 'zh-tw'];
+export const supportedBaseLocales = ['ar', 'cy', 'da', 'de', 'en', 'es', 'fr', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh'];
+export const supportedLangpacks = ['ar', 'cy', 'da', 'de', 'en', 'en-gb', 'es', 'es-es', 'fr', 'fr-fr', 'fr-on', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh-cn', 'zh-tw'];
 export const supportedLocalesDetails = [
 	{ code: 'ar-sa', dir: 'rtl', name: 'العربية (المملكة العربية السعودية)' },
 	{ code: 'cy-gb', dir: 'ltr', name: 'Cymraeg (Y Deyrnas Unedig)' },
@@ -14,6 +14,7 @@ export const supportedLocalesDetails = [
 	{ code: 'fr-ca', dir: 'ltr', name: 'Français (Canada)' },
 	{ code: 'fr-fr', dir: 'ltr', name: 'Français (France)' },
 	{ code: 'fr-on', dir: 'ltr', name: 'Français (Ontario)' },
+	{ code: 'haw-us', dir: 'ltr', name: 'ʻŌlelo Hawaiʻi (ʻAmelika Hui Pū ʻIa)' },
 	{ code: 'hi-in', dir: 'ltr', name: 'हिंदी (भारत)' },
 	{ code: 'ja-jp', dir: 'ltr', name: '日本語 (日本)' },
 	{ code: 'ko-kr', dir: 'ltr', name: '한국어 (대한민국)' },


### PR DESCRIPTION
[GAUD-7412](https://desire2learn.atlassian.net/browse/GAUD-7412): Add `haw` as supported language in `brightspace-ui/intl`

Adds `haw`/`haw-us` as a supported lang/locale. More data for dates/times, numbers etc. will be added separately.

[GAUD-7412]: https://desire2learn.atlassian.net/browse/GAUD-7412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ