### PR TITLE
Add a datalist of supported locales using their local names

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -28,7 +28,7 @@
 		window.intl = { ...common, ...dateTime, ...fileSize, ...list, ...number, ...localize };
 
 		render(
-			common.supportedLocalesDetails.map(({ code, name }) => html`<option value="${code}">${name}</option>`),
+			common.supportedLocalesDetails.map(({ code, localName }) => html`<option value="${code}">${localName}</option>`),
 			document.querySelector('#languages')
 		);
 	</script>
@@ -57,6 +57,7 @@
 		const htmlLangInput = document.getElementById('html-lang');
 
 		document.getElementById('apply-lang').onclick = () => {
+			debugger;
 			htmlElement.lang = htmlLangInput.value;
 		};
 	</script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -17,6 +17,7 @@
 		}
 	</style>
 	<script type="module">
+		import { html, render } from 'lit';
 		import * as common from '../lib/common.js';
 		import * as dateTime from '../lib/dateTime.js';
 		import * as fileSize from '../lib/fileSize.js';
@@ -25,6 +26,11 @@
 		import * as localize from '../lib/localize.js';
 
 		window.intl = { ...common, ...dateTime, ...fileSize, ...list, ...number, ...localize };
+
+		render(
+			common.supportedLocalesDetails.map(({ code, name }) => html`<option value="${code}">${name}</option>`),
+			document.querySelector('#languages')
+		);
 	</script>
 </head>
 <body>
@@ -33,7 +39,9 @@
 
 	<div class="settings">
 		<h2>Settings</h2>
-		<label>HTML lang attribute: <input id="html-lang" type="text"></label>
+		<label>HTML lang attribute:
+		<input id="html-lang" type="text" list="languages"></label>
+		<datalist id="languages"></datalist>
 		<button id="apply-lang">Apply</button>
 	</div>
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,6 +1,14 @@
 export const defaultLocale = 'en';
 export const supportedBaseLocales = ['ar', 'cy', 'da', 'de', 'en', 'es', 'fr', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh'];
 export const supportedLangpacks = ['ar', 'cy', 'da', 'de', 'en', 'en-gb', 'es', 'es-es', 'fr', 'fr-fr', 'fr-on', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'tr', 'zh-cn', 'zh-tw'];
+
+function updateLocalNames() {
+	const localName = new Intl.DisplayNames(documentLocaleSettings.language || navigator.language, { type: 'language' });
+	supportedLocalesDetails.forEach(l => {
+		l.localName = localName.of(l.overrideCode || l.code);
+	});
+}
+
 export const supportedLocalesDetails = [
 	{ code: 'ar-sa', dir: 'rtl', name: 'العربية (المملكة العربية السعودية)' },
 	{ code: 'cy-gb', dir: 'ltr', name: 'Cymraeg (Y Deyrnas Unedig)' },
@@ -10,10 +18,10 @@ export const supportedLocalesDetails = [
 	{ code: 'en-gb', dir: 'ltr', name: 'English (United Kingdom)' },
 	{ code: 'en-us', dir: 'ltr', name: 'English (United States)' },
 	{ code: 'es-es', dir: 'ltr', name: 'Español (España)' },
-	{ code: 'es-mx', dir: 'ltr', name: 'Español (Latinoamérica)' },
+	{ code: 'es-mx', overrideCode: 'es-419', dir: 'ltr', name: 'Español (Latinoamérica)' },
 	{ code: 'fr-ca', dir: 'ltr', name: 'Français (Canada)' },
 	{ code: 'fr-fr', dir: 'ltr', name: 'Français (France)' },
-	{ code: 'fr-on', dir: 'ltr', name: 'Français (Ontario)' },
+	{ code: 'fr-on', overrideCode: 'fr-CA-Ontario' , dir: 'ltr', name: 'Français (Ontario)' },
 	{ code: 'haw-us', dir: 'ltr', name: 'ʻŌlelo Hawaiʻi (ʻAmelika Hui Pū ʻIa)' },
 	{ code: 'hi-in', dir: 'ltr', name: 'हिंदी (भारत)' },
 	{ code: 'ja-jp', dir: 'ltr', name: '日本語 (日本)' },
@@ -23,8 +31,8 @@ export const supportedLocalesDetails = [
 	{ code: 'pt-br', dir: 'ltr', name: 'Português (Brasil)' },
 	{ code: 'sv-se', dir: 'ltr', name: 'Svenska (Sverige)' },
 	{ code: 'tr-tr', dir: 'ltr', name: 'Türkçe (Türkiye)' },
-	{ code: 'zh-cn', dir: 'ltr', name: '中文(简体)' },
-	{ code: 'zh-tw', dir: 'ltr', name: '中文(繁体)' }
+	{ code: 'zh-cn', overrideCode: 'zh-hans', dir: 'ltr', name: '中文(简体)' },
+	{ code: 'zh-tw', overrideCode: 'zh-hant', dir: 'ltr', name: '中文(繁体)' }
 ];
 export const supportedLocales = supportedLocalesDetails.map((l) => l.code);
 
@@ -225,3 +233,8 @@ export function getDocumentLocaleSettings() {
 	}
 	return documentLocaleSettings;
 }
+
+(() => {
+	getDocumentLocaleSettings().addChangeListener(updateLocalNames);
+	updateLocalNames();
+})()


### PR DESCRIPTION
Adds a datalist to the lang attribute input on the demo page to make finding supported locales easier/searchable while still allowing "arbitrary" codes (e.g. `fr-be`, `xyz`)

Also adds local names to `supportedLocalesDetails` that will remain undocumented for now. This sets up some future work to transition to browser internationalization APIs and standard codes that either better represent our locales or are better recognized by APIs.

![Screenshot 2025-03-05 at 12 33 40 PM](https://github.com/user-attachments/assets/01194730-0a0b-4992-9bde-d094b8ad98a5)
