### PR TITLE
Filter out bad locales and fail gracefully

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -93,7 +93,7 @@ class DocumentLocaleSettings {
 
 	constructor() {
 		this._cache = new Map();
-		this._htmlElem = window.document.getElementsByTagName('html')[0];
+		this._htmlElem = document.documentElement;
 		this._listeners = [];
 		this._overrides = {};
 		this._observer = new MutationObserver(this._handleObserverChange.bind(this));
@@ -227,8 +227,11 @@ export function getDocumentLocaleSettings() {
 	return documentLocaleSettings;
 }
 
+const localeRegEx = /[^a-zA-Z0-9-]/g;
+
 function updateLocalNames() {
-	const localName = new Intl.DisplayNames(documentLocaleSettings.language || navigator.language, { type: 'language' });
+	const possibleLocales = [documentLocaleSettings.language, navigator.language, defaultLocale].filter(l => l && !localeRegEx.test(l));
+	const localName = new Intl.DisplayNames(possibleLocales, { type: 'language' });
 	supportedLocalesDetails.forEach(l => {
 		l.localName = localName.of(l.overrideCode || l.code);
 	});

--- a/lib/common.js
+++ b/lib/common.js
@@ -231,7 +231,12 @@ const localeRegEx = /[^a-zA-Z0-9-]/g;
 
 function updateLocalNames() {
 	const possibleLocales = [documentLocaleSettings.language, navigator.language, defaultLocale].filter(l => l && !localeRegEx.test(l));
-	const localName = new Intl.DisplayNames(possibleLocales, { type: 'language' });
+	let localName;
+	try {
+		localName = new Intl.DisplayNames(possibleLocales, { type: 'language' });
+	} catch {
+		return;
+	}
 	supportedLocalesDetails.forEach(l => {
 		l.localName = localName.of(l.overrideCode || l.code);
 	});


### PR DESCRIPTION
[GAUD-7600](https://desire2learn.atlassian.net/browse/GAUD-7600): intl: Filter bad locales and fail gracefully

In addition to the invalid `en-US@posix` locale, some environments have an empty string. This fix is in addition to [setting the `LANG` env var](https://github.com/BrightspaceUI/testing/pull/630/files), which is preferable to these fallbacks and failures.

- Fall back to `defaultLocale`
- Filter out [invalid locales](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument)
- Fail gracefully via try-catch

[GAUD-7600]: https://desire2learn.atlassian.net/browse/GAUD-7600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ