### PR TITLE
GAUD-8233: deep copy defaults upon reset

### DIFF
--- a/lib/document-locale-settings.js
+++ b/lib/document-locale-settings.js
@@ -75,7 +75,7 @@ export class DocumentLocaleSettings {
 		this._cache.clear();
 		this._language = this._languageInitial;
 		this._listeners = [];
-		Object.assign(this, DEFAULTS);
+		Object.assign(this, JSON.parse(JSON.stringify(DEFAULTS)));
 	}
 
 	sync() {

--- a/test/common.test.js
+++ b/test/common.test.js
@@ -26,6 +26,14 @@ describe('common', () => {
 		expect(defaultLocale).to.equal('en');
 	});
 
+	it('should deep copy the default locale settings', () => {
+		documentLocaleSettings.timezone.name = 'Foo';
+		documentLocaleSettings.timezone.identifier = 'bar';
+		documentLocaleSettings.reset();
+		expect(documentLocaleSettings.timezone.name).to.equal('');
+		expect(documentLocaleSettings.timezone.identifier).to.equal('');
+	});
+
 	describe('getLanguage', () => {
 		it('should use "fallback" if no "lang" is present', async() => {
 			htmlElem.setAttribute('data-lang-default', 'fr');


### PR DESCRIPTION
Fixing a regression from #248.

For better or worse, `localize-behavior` is [directly modifying](https://github.com/BrightspaceUI/localize-behavior/blob/main/test/d2l-localize-behavior.test.js#L326) the locale setting's timezone name and identifier. Because those are both just pointers to `DEFAULTS`'s references, in doing so it's actually changing the `DEFAULTS`. Then when `reset()` does an `Object.assign` they propagate.

The fix here is to do a deep copy of `DEFAULTS` during `reset()`.

This will fix the [failing CI in localize-behavior](https://github.com/BrightspaceUI/localize-behavior/pull/67).