### PR TITLE
NTNGL-4668: introduce localizeCommon

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,13 @@ const localizer = new Localize({
 });
 ```
 
+#### localizeCommon
+
+The localized value of the following common terms can be accessed using `localizeCommon(name)`:
+
+Navigation
+* `navigation:back:title` (Back) 
+
 #### localizeCharacter
 
 The localized value of the following characters can be accessed using `localizeCharacter(char)`:

--- a/lang/ar.js
+++ b/lang/ar.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "الخط العمودي", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "علامة الاستفهام", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "علامة الاقتباس", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "الخلف", // term for navigating back to the previous page in Title Case
 };

--- a/lang/cy.js
+++ b/lang/cy.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "pibell", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "gofynnod", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "dyfynnod", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Yn ôl", // term for navigating back to the previous page in Title Case
 };

--- a/lang/da.js
+++ b/lang/da.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "lodret streg", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "spørgsmålstegn", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "anførselstegn", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Tilbage", // term for navigating back to the previous page in Title Case
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "Senkrechter Strich", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "Fragezeichen", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "Anführungszeichen", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Zurück", // term for navigating back to the previous page in Title Case
 };

--- a/lang/en-gb.js
+++ b/lang/en-gb.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "pipe", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "question mark", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "quotation mark", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Back", // term for navigating back to the previous page in Title Case
 };

--- a/lang/en.js
+++ b/lang/en.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "pipe", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "question mark", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "quotation mark", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Back", // term for navigating back to the previous page in Title Case
 };

--- a/lang/es-es.js
+++ b/lang/es-es.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "pleca", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "signo de interrogación", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "comillas", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Anterior", // term for navigating back to the previous page in Title Case
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "Barra vertical", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "signo de interrogación", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "comilla", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Anterior", // term for navigating back to the previous page in Title Case
 };

--- a/lang/fr-fr.js
+++ b/lang/fr-fr.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "barre verticale", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "point d’interrogation", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "guillemet anglais", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Retour", // term for navigating back to the previous page in Title Case
 };

--- a/lang/fr-on.js
+++ b/lang/fr-on.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "barre verticale", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "point d'interrogation", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "guillemet", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Retour", // term for navigating back to the previous page in Title Case
 };

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "barre verticale", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "point d'interrogation", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "guillemet", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Retour", // term for navigating back to the previous page in Title Case
 };

--- a/lang/haw.js
+++ b/lang/haw.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "paipu", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "kaha ninau", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "kaha puana'i", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Ke kua", // term for navigating back to the previous page in Title Case
 };

--- a/lang/hi.js
+++ b/lang/hi.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "पाइप", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "प्रश्नवाचक चिह्न", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "उद्धरण चिह्न", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "वापस जाएँ", // term for navigating back to the previous page in Title Case
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "縦棒", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "疑問符", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "引用符", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "戻る", // term for navigating back to the previous page in Title Case
 };

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "수직선", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "물음표", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "따옴표", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "뒤로", // term for navigating back to the previous page in Title Case
 };

--- a/lang/mi.js
+++ b/lang/mi.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "paipa", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "tohu pātai", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "tohu whakatikatika", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Whakamuri", // term for navigating back to the previous page in Title Case
 };

--- a/lang/nl.js
+++ b/lang/nl.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "sluisteken", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "vraagteken", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "aanhalingsteken", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Terug", // term for navigating back to the previous page in Title Case
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "pipe", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "ponto de interrogação", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "aspas", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Voltar", // term for navigating back to the previous page in Title Case
 };

--- a/lang/sv.js
+++ b/lang/sv.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "lodstreck", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "frågetecken", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "citattecken", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Tillbaka", // term for navigating back to the previous page in Title Case
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "düz çizgi", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "soru işareti", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "tırnak işareti", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "Geri", // term for navigating back to the previous page in Title Case
 };

--- a/lang/zh-cn.js
+++ b/lang/zh-cn.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "管道符号", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "问号", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "引号", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "返回", // term for navigating back to the previous page in Title Case
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -12,4 +12,5 @@ export default {
 	"intl-common:characters:pipe": "豎線", // short name or description of the "|" character
 	"intl-common:characters:questionMark": "問號", // short name or description of the "?" character
 	"intl-common:characters:quotationMark": "英文雙引號", // short name or description of the '"' character
+	"intl-common:navigation:back:title": "返回", // term for navigating back to the previous page in Title Case
 };

--- a/lib/localize.js
+++ b/lib/localize.js
@@ -20,6 +20,7 @@ const characterMap = new Map([
 	['?', 'questionMark'],
 	['"', 'quotationMark']
 ]);
+const commonTerms = ['navigation:back:title'];
 const commonResources = new Map();
 export let commonResourcesImportCount = 0;
 
@@ -97,6 +98,17 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 		const value = this.localize(`intl-common:characters:${characterMap.get(char)}`);
 		if (value.length === 0) {
 			throw new Error('localizeCharacter() cannot be used unless loadCommon in localizeConfig is enabled');
+		}
+		return value;
+	}
+
+	localizeCommon(name) {
+		if (commonTerms.indexOf(name) === -1) {
+			throw new Error(`localizeCommon() term not found: "${name}"`);
+		}
+		const value = this.localize(`intl-common:${name}`);
+		if (value.length === 0) {
+			throw new Error('localizeCommon() cannot be used unless loadCommon in localizeConfig is enabled');
 		}
 		return value;
 	}

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -227,6 +227,26 @@ describe('Localize', () => {
 
 		});
 
+		describe('localizeCommon', () => {
+
+			it('should localize "Back"', async() => {
+				const localized = localizerCommon.localizeCommon('navigation:back:title');
+				expect(localized).to.equal('Back');
+			});
+
+			it('should throw an error for unknown terms', async() => {
+				expect(() => localizerCommon.localizeCommon('unknown'))
+					.to.throw('localizeCommon() term not found: "unknown"');
+			});
+
+			it('should throw an error if common resources are not loaded', async() => {
+				await localizer.ready;
+				expect(() => localizer.localizeCommon('navigation:back:title'))
+					.to.throw('localizeCommon() cannot be used unless loadCommon in localizeConfig is enabled');
+			});
+
+		});
+
 	});
 
 	describe('localizeHTML()', () => {


### PR DESCRIPTION
This adds something we've talked about for a while: a `localizeCommon(name)` for terms that show up a lot.

The motivation for doing this now is that Insights just added yet another usage of the term "Back" for the short button text in their immersive navigation usage. I copied the translations from the LMS's `Standard.Buttons.btnBack` term.

If we like the approach here, I'm happy to add a few more related "navigation" terms (Forward, Next, Previous, any others?).