### PR TITLE
Nix basePath for variable dynamic imports

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="" timezone>
+<html lang="en-CA" data-timezone='{"name":"Canada - Toronto", "identifier":"America/Toronto"}'>
 <head>
 	<title>BrightspaceUI/intl Test Harness</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/lib/_timeZones/mapper.js
+++ b/lib/_timeZones/mapper.js
@@ -172,12 +172,12 @@ export class TimeZoneMapper {
    * @param {string} basePath - Base path to the timeZone mappings directory
    * @returns {Promise<void>}
    */
-	async loadMappings(basePath = './data/') {
+	async loadMappings() {
 		if (this.loaded) return;
 
 		try {
 			for (const moduleName of this.modules) {
-				const module = await import(`${basePath}${moduleName}.js`);
+				const module = await import(`./data/${moduleName}.js`);
 				const timeZoneData = module.default || module[`${moduleName}TimeZones`];
 
 				// Merge all timeZone data into the main mappings


### PR DESCRIPTION
The variable dynamic import needs to be a relative path, and I don't think there's currently reason point it to another directory so I'm dumping that part.

Also through in some demo document settings.