### PR TITLE
Fix OSLO URL origin for `srcdoc` iframes

### DIFF
--- a/lib/localize.js
+++ b/lib/localize.js
@@ -241,13 +241,13 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 					if (oslo.collection) {
 						languageId = supportedLocalesDetails.find(l => l.code === osloLang || l.pack === osloLang)?.id;
 						if (languageId) {
-							const batch = oslo.batch && new URL(oslo.batch, document.location.origin);
+							const batch = oslo.batch && new URL(oslo.batch, self.origin);
 							if (batch && languageId !== batch.searchParams.get('languageId')) {
 								batch.searchParams.set('languageId', languageId);
 								oslo.batch = batch.toString();
 							}
 
-							const collection = new URL(oslo.collection, document.location.origin);
+							const collection = new URL(oslo.collection, self.origin);
 							if (languageId !== collection.searchParams.get('languageId')) {
 								collection.searchParams.set('languageId', languageId);
 								oslo.collection = collection.toString();

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -316,7 +316,7 @@ describe('getLocalizeClass', () => {
 			});
 		});
 
-		it('should generate valid OSLO absolute URLs inside of a srcdoc', async () => {
+		it('should generate valid OSLO absolute URLs inside of a srcdoc', async() => {
 			const iframe = document.createElement('iframe');
 			const p = new Promise(r => {
 				iframe.onload = async() => {

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -316,10 +316,10 @@ describe('getLocalizeClass', () => {
 			});
 		});
 
-		it('should generate valid OSLO absolute URLs inside of a srcdoc', async() => {
+		it('should generate valid OSLO absolute URLs inside of a srcdoc', async () => {
 			const iframe = document.createElement('iframe');
 			const p = new Promise(r => {
-				iframe.onload = async() => {
+				iframe.onload = async () => {
 					const iframeLocalizeClass = iframe.contentWindow.getLocalizeClass();
 					await iframeLocalizeClass._getLocalizeResources(['en'], config);
 					expect(iframe.contentWindow.self.origin).to.equal(document.location.origin);
@@ -344,7 +344,7 @@ describe('getLocalizeClass', () => {
 				</html>`;
 			document.body.appendChild(iframe);
 			await p;
-		})
+		});
 
 	});
 });

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -1,5 +1,5 @@
 import { commonResourcesImportCount, getLocalizeClass, Localize, localizeMarkup } from '../lib/localize.js';
-import { expect, fixture, aTimeout } from '@brightspace-ui/testing';
+import { expect, fixture } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '../lib/common.js';
 import { spy } from 'sinon';
 

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -1,5 +1,5 @@
 import { commonResourcesImportCount, getLocalizeClass, Localize, localizeMarkup } from '../lib/localize.js';
-import { expect, fixture } from '@brightspace-ui/testing';
+import { expect, fixture, aTimeout } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '../lib/common.js';
 import { spy } from 'sinon';
 
@@ -315,5 +315,36 @@ describe('getLocalizeClass', () => {
 				expect(resources.language).to.equal('en'); // always en-US langpack
 			});
 		});
+
+		it('should generate valid OSLO absolute URLs inside of a srcdoc', async() => {
+			const iframe = document.createElement('iframe');
+			const p = new Promise(r => {
+				iframe.onload = async() => {
+					const iframeLocalizeClass = iframe.contentWindow.getLocalizeClass();
+					await iframeLocalizeClass._getLocalizeResources(['en'], config);
+					expect(iframe.contentWindow.self.origin).to.equal(document.location.origin);
+					expect(iframe.contentWindow.documentLocaleSettings.oslo.batch).to.equal(`${document.location.origin}/batch/url?languageId=1`);
+					r();
+				};
+			});
+			iframe.srcdoc = `
+				<html>
+				<head>
+					<script type="module">
+						import { getDocumentLocaleSettings } from '../lib/common.js';
+						import { getLocalizeClass } from '../lib/localize.js';
+						window.getLocalizeClass = getLocalizeClass;
+
+						window.documentLocaleSettings = getDocumentLocaleSettings();
+						window.documentLocaleSettings.oslo.batch = '/batch/url';
+						window.documentLocaleSettings.oslo.collection = '/collection/url';
+					</script>
+				</head>
+				<body></body>
+				</html>`;
+			document.body.appendChild(iframe);
+			await p;
+		})
+
 	});
 });

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -319,7 +319,7 @@ describe('getLocalizeClass', () => {
 		it('should generate valid OSLO absolute URLs inside of a srcdoc', async () => {
 			const iframe = document.createElement('iframe');
 			const p = new Promise(r => {
-				iframe.onload = async () => {
+				iframe.onload = async() => {
 					const iframeLocalizeClass = iframe.contentWindow.getLocalizeClass();
 					await iframeLocalizeClass._getLocalizeResources(['en'], config);
 					expect(iframe.contentWindow.self.origin).to.equal(document.location.origin);


### PR DESCRIPTION
[GAUD-9720](https://desire2learn.atlassian.net/browse/GAUD-9720): intl: OSLO API routes fail to construct

When using a `srcdoc` iframe, `document.location.origin` is `null`, so switch to `self.origin`

[GAUD-9720]: https://desire2learn.atlassian.net/browse/GAUD-9720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ