### PR TITLE
fix: move month prefixes (GAUD-9698)

### DIFF
--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -741,11 +741,11 @@ export function getDateTimeDescriptor() {
 				weekendEndDay = 5;
 				break;
 			case 'ca':
-				dateFormats = ['dddd, d MMMM\' del \'yyyy', 'd MMMM\' del \'yyyy', 'd/M/yy', 'MMMM\' del \'yyyy', 'd MMMM', 'd MMM'];
+				dateFormats = ['dddd, d\' de \'MMMM\' del \'yyyy', 'd\' de \'MMMM\' del \'yyyy', 'd/M/yy', 'MMMM\' del \'yyyy', 'd\' de \'MMMM', 'd\' de \'MMM'];
 				dayPeriods = ['a. m.', 'p. m.'];
 				months = [
-					['de gener', 'de febrer', 'de març', 'd’abril', 'de maig', 'de juny', 'de juliol', 'd’agost', 'de setembre', 'd’octubre', 'de novembre', 'de desembre'],
-					['de gen.', 'de febr.', 'de març', 'd’abr.', 'de maig', 'de juny', 'de jul.', 'd’ag.', 'de set.', 'd’oct.', 'de nov.', 'de des.']
+					['gener', 'febrer', 'març', 'abril', 'maig', 'juny', 'juliol', 'agost', 'setembre', 'octubre', 'novembre', 'desembre'],
+					['gen.', 'febr.', 'març', 'abr.', 'maig', 'juny', 'jul.', 'ag.', 'set.', 'oct.', 'nov.', 'des.']
 				];
 				days = [
 					['diumenge', 'dilluns', 'dimarts', 'dimecres', 'dijous', 'divendres', 'dissabte'],

--- a/test/dateTime.test.js
+++ b/test/dateTime.test.js
@@ -663,8 +663,8 @@ describe('dateTime', () => {
 		[
 			{ locale: 'ar', expect: ['الثلاثاء, 4 يونيو, 2019', '04 يونيو, 2019', '04/06/2019', 'يونيو, 2019', '4 يونيو', '4 يونيو', 'الثلاثاء', 'ثلاثاء', 'يونيو', 'يونيو'] },
 			{ locale: 'ar-SA', expect: ['الثلاثاء, 4 يونيو, 2019', '04 يونيو, 2019', '04/06/2019', 'يونيو, 2019', '4 يونيو', '4 يونيو', 'الثلاثاء', 'ثلاثاء', 'يونيو', 'يونيو'] },
-			{ locale: 'ca', expect: ['dimarts, 4 de juny del 2019', '4 de juny del 2019', '4/6/19', 'de juny del 2019', '4 de juny', '4 de juny', 'dimarts', 'dt.', 'de juny', 'de juny'] },
-			{ locale: 'ca-ES', expect: ['dimarts, 4 de juny del 2019', '4 de juny del 2019', '4/6/19', 'de juny del 2019', '4 de juny', '4 de juny', 'dimarts', 'dt.', 'de juny', 'de juny'] },
+			{ locale: 'ca', expect: ['dimarts, 4 de juny del 2019', '4 de juny del 2019', '4/6/19', 'juny del 2019', '4 de juny', '4 de juny', 'dimarts', 'dt.', 'juny', 'juny'] },
+			{ locale: 'ca-ES', expect: ['dimarts, 4 de juny del 2019', '4 de juny del 2019', '4/6/19', 'juny del 2019', '4 de juny', '4 de juny', 'dimarts', 'dt.', 'juny', 'juny'] },
 			{ locale: 'cy-GB', expect: ['Dydd Mawrth, 4 Mehefin 2019', '04 Mehefin 2019', '04/06/2019', 'Mehefin 2019', '4 Mehefin', '4 Meh', 'Dydd Mawrth', 'Maw', 'Mehefin', 'Meh'] },
 			{ locale: 'da', expect: ['tirsdag den 4. juni 2019', '4. jun.. 2019', '04.06.2019', 'juni 2019', '4. juni', '4. jun.', 'tirsdag', 'tir.', 'juni', 'jun.'] },
 			{ locale: 'da-DK', expect: ['tirsdag den 4. juni 2019', '4. jun.. 2019', '04.06.2019', 'juni 2019', '4. juni', '4. jun.', 'tirsdag', 'tir.', 'juni', 'jun.'] },


### PR DESCRIPTION
We're still waiting for final confirmation, but I'm 99% sure we don't want the prefixes in the month names themselves -- they should move to our date format strings that contain a month and day of the month, just like Spanish.

There's still the open issue of it being `d'abril` instead of `de abril`, but we can cross that bridge if it becomes necessary later.