### PR TITLE
Remove Saudi Arabia from Arabic display name

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -5,7 +5,7 @@ export const supportedBaseLocales = ['ar', 'ca', 'cy', 'da', 'de', 'en', 'es', '
 export const supportedLangpacks = ['ar', 'ca', 'cy', 'da', 'de', 'en', 'en-gb', 'es', 'es-es', 'fr', 'fr-fr', 'fr-on', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'th', 'tr', 'vi', 'zh-cn', 'zh-tw'];
 
 export const supportedLocalesDetails = [
-	{ id: 16, code: 'ar-sa', pack: 'ar', dir: 'rtl', name: 'العربية (المملكة العربية السعودية)' },
+	{ id: 16, code: 'ar-sa', pack: 'ar', dir: 'rtl', name: 'العربية' },
 	{ id: 38, code: 'ca-es', pack: 'ca', dir: 'ltr', name: 'Català (Espanya)' },
 	{ id: 31, code: 'cy-gb', pack: 'cy', dir: 'ltr', name: 'Cymraeg (Y Deyrnas Unedig)' },
 	{ id: 28, code: 'da-dk', pack: 'da', dir: 'ltr', name: 'Dansk (danmark)' },


### PR DESCRIPTION
[GAUD-9949](https://desire2learn.atlassian.net/browse/GAUD-9949): Arabic language display name should not include a region

[GAUD-9949]: https://desire2learn.atlassian.net/browse/GAUD-9949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ