### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "/helpers"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564