### PR TITLE
Only overwrite languageId when requested

### DIFF
--- a/lib/localize.js
+++ b/lib/localize.js
@@ -238,8 +238,9 @@ export const getLocalizeClass = (superclass = class {}) => class LocalizeClass e
 				if (osloCollection) {
 					const oslo = this.documentLocaleSettings.oslo;
 					let languageId = 0;
-					if (oslo.collection) {
-						languageId = supportedLocalesDetails.find(l => l.code === osloLang || l.pack === osloLang)?.id;
+					const doc = document.documentElement;
+					if (doc.hasAttribute('data-custom-lang') && oslo.collection) {
+						languageId = Number(doc.dataset.languageId) || supportedLocalesDetails.find(l => l.code === osloLang || l.pack === osloLang)?.id;
 						if (languageId) {
 							const batch = oslo.batch && new URL(oslo.batch, self.origin);
 							if (batch && languageId !== batch.searchParams.get('languageId')) {

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -299,17 +299,17 @@ describe('getLocalizeClass', () => {
 			expect(documentLocaleSettings.oslo.batch).to.equal(`${document.location.origin}/batch/url?languageId=1`);
 		});
 
-		it('should update OSLO batch URL to use `data-language-id` if present', async () => {
+		it('should update OSLO batch URL to use `data-language-id` if present', async() => {
 			document.documentElement.dataset.languageId = '1009';
 			await LocalizeClass._getLocalizeResources(['en-US'], config);
 			expect(documentLocaleSettings.oslo.batch).to.equal(`${document.location.origin}/batch/url?languageId=1009`);
 		});
 
 		it('should not update OSLO URLs if document flag is not present', async() => {
-			delete document.documentElement.dataset.customLang
+			delete document.documentElement.dataset.customLang;
 			await LocalizeClass._getLocalizeResources(['fr-be'], config);
 			expect(documentLocaleSettings.oslo.batch).to.equal('/batch/url');
-			expect(documentLocaleSettings.oslo.collection).to.equal('/collection/url')
+			expect(documentLocaleSettings.oslo.collection).to.equal('/collection/url');
 		});
 
 		it('should not update OSLO URLs if collection is null', async() => {

--- a/test/localize.test.js
+++ b/test/localize.test.js
@@ -275,11 +275,13 @@ describe('getLocalizeClass', () => {
 		beforeEach(() => {
 			documentLocaleSettings.oslo.batch = '/batch/url';
 			documentLocaleSettings.oslo.collection = '/collection/url';
+			document.documentElement.dataset.customLang = '';
 		});
 
 		afterEach(() => {
 			documentLocaleSettings.oslo.batch = null;
 			documentLocaleSettings.oslo.collection = null;
+			delete document.documentElement.dataset.languageId;
 		});
 
 		it('should update OSLO batch URL to match the resolved language', async() => {
@@ -295,6 +297,19 @@ describe('getLocalizeClass', () => {
 		it('should update OSLO batch URL to use en-US given no langs', async() => {
 			await LocalizeClass._getLocalizeResources([], config);
 			expect(documentLocaleSettings.oslo.batch).to.equal(`${document.location.origin}/batch/url?languageId=1`);
+		});
+
+		it('should update OSLO batch URL to use `data-language-id` if present', async () => {
+			document.documentElement.dataset.languageId = '1009';
+			await LocalizeClass._getLocalizeResources(['en-US'], config);
+			expect(documentLocaleSettings.oslo.batch).to.equal(`${document.location.origin}/batch/url?languageId=1009`);
+		});
+
+		it('should not update OSLO URLs if document flag is not present', async() => {
+			delete document.documentElement.dataset.customLang
+			await LocalizeClass._getLocalizeResources(['fr-be'], config);
+			expect(documentLocaleSettings.oslo.batch).to.equal('/batch/url');
+			expect(documentLocaleSettings.oslo.collection).to.equal('/collection/url')
 		});
 
 		it('should not update OSLO URLs if collection is null', async() => {
@@ -328,7 +343,7 @@ describe('getLocalizeClass', () => {
 				};
 			});
 			iframe.srcdoc = `
-				<html>
+				<html data-custom-lang>
 				<head>
 					<script type="module">
 						import { getDocumentLocaleSettings } from '../lib/common.js';


### PR DESCRIPTION
[GAUD-10152](https://desire2learn.atlassian.net/browse/GAUD-10152): OSLO > Custom languages are not resolved via oslo - falls back to parent language

In order for OSLO to pull down custom langpacks that use (via a custom locale) locale codes that we already support, we need to limit overwriting the `languageId`. Currently we always check if there is a mismatch between the document language and the OSLO `languageId`. With a custom langpack/locale, this mismatch could be intentional.

[GAUD-10152]: https://desire2learn.atlassian.net/browse/GAUD-10152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ