### PR TITLE
Fall back to default locale

### DIFF
--- a/lib/locale-data/current.js
+++ b/lib/locale-data/current.js
@@ -1,6 +1,5 @@
+import { defaultLocale, resolveSupportedLocale } from './supported.js';
 import { getDocumentLocaleSettings } from '../common.js';
-
-import { resolveSupportedLocale } from './supported.js';
 
 const localeDataTarget = {};
 
@@ -21,7 +20,7 @@ Object.defineProperty(localeDataTarget, 'finally', { value: (...args) => localeD
 
 async function setLocaleData() {
 	if (currentLocale === documentLocaleSettings.language) return;
-	const resolvedLanguage = resolveSupportedLocale(documentLocaleSettings.language);
+	const resolvedLanguage = resolveSupportedLocale(documentLocaleSettings.language || documentLocaleSettings.fallbackLanguage || defaultLocale);
 	const newData = deepFreeze((await import(`./locales/${resolvedLanguage}.js`)).default);
 
 	Object.keys(newData).forEach(k => localeDataTarget[k] = newData[k]);

--- a/lib/locale-data/supported.js
+++ b/lib/locale-data/supported.js
@@ -39,19 +39,21 @@ export const supportedLocales = supportedLocalesDetails.map(l => l.code);
 export function resolveSupportedLocale(localeTags) {
 	localeTags = [].concat(localeTags);
 
-	for (const localeTag of localeTags) {
-		const localeTagLower = localeTag.toLowerCase();
-		const locale = supportedLocalesDetails.find(l => [l.overrideCode, l.code].includes(localeTagLower));
-		if (locale) {
-			return locale.overrideCode || locale.source;
+	if (localeTags.length) {
+		for (const localeTag of localeTags) {
+			const localeTagLower = localeTag.toLowerCase();
+			const locale = supportedLocalesDetails.find(l => [l.overrideCode, l.code].includes(localeTagLower));
+			if (locale) {
+				return locale.overrideCode || locale.source;
+			}
 		}
-	}
 
-	for (const localeTag of localeTags) {
-		const lang = localeTag.split('-')[0];
-		const locale = supportedLocalesDetails.find(l => l.source === lang);
-		if (locale) {
-			return locale.overrideCode || locale.source;
+		for (const localeTag of localeTags) {
+			const lang = localeTag.split('-')[0];
+			const locale = supportedLocalesDetails.find(l => l.source === lang);
+			if (locale) {
+				return locale.overrideCode || locale.source;
+			}
 		}
 	}
 	return defaultLocale;

--- a/test/current.test.js
+++ b/test/current.test.js
@@ -19,7 +19,18 @@ describe('current', () => {
 
 	describe('localeData', () => {
 
-		it('should be populated with the default locale data on load', () => {
+		it('should be populated with the document lang data on load', () => {
+			expect(localeData.sourceLocale).to.equal('en');
+			expect(localeData.localeCode).to.equal('en');
+			expect(Object.keys(localeData).length).to.be.above(0);
+		});
+
+		it('should fall back to the default locale', async() => {
+			documentLocaleSettings.language = 'fr';
+			await localeData;
+			expect(localeData.sourceLocale).to.equal('fr');
+			documentLocaleSettings.language = null;
+			await localeData;
 			expect(localeData.sourceLocale).to.equal('en');
 			expect(localeData.localeCode).to.equal('en');
 			expect(Object.keys(localeData).length).to.be.above(0);


### PR DESCRIPTION
Whoopsies! We need to fall back to the default locale so we always load something regardless of document language settings.

https://d2l.slack.com/archives/C0PHG3QB0/p1784719125512429

[GAUD-9717](https://desire2learn.atlassian.net/browse/GAUD-9717): Rewrite intl/common and intl/dateTime to use contained data sets per locale

[GAUD-9717]: https://desire2learn.atlassian.net/browse/GAUD-9717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ