### PR TITLE
Add skeleton support to existing date/time functions

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -28,8 +28,9 @@
 		import * as timeZonesData from '../lib/_timeZones/data/index.js';
 		import * as timeZones from '../lib/timeZones.js';
 		import * as supported from '../lib/locale-data/supported.js';
+		import { formatDateTimeSkeleton } from '../lib/dateTimeSkeleton.js';
 
-		window.intl = { ...common, ...dateTime, ...fileSize, ...list, ...localize, ...number, ...supported, timeZones: { ...timeZonesMapper, data: timeZonesData, basic: timeZones } };
+		window.intl = { ...common, ...dateTime, ...fileSize, ...list, ...localize, ...number, ...supported, formatDateTimeSkeleton, timeZones: { ...timeZonesMapper, data: timeZonesData, basic: timeZones } };
 
 		render(
 			common.supportedLocalesDetails.map(({ code, localName }) => html`<option value="${code}">${localName}</option>`),

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -1,4 +1,5 @@
 import { getDocumentLocaleSettings, merge } from './common.js';
+import { formatDateTimeSkeleton } from './dateTimeSkeleton.js';
 import { localeData } from './locale-data/current.js';
 import { resolveSupportedLocale } from './locale-data/supported.js';
 
@@ -869,12 +870,13 @@ export function getDateTimeDescriptor() {
 	});
 }
 
-export function formatTime(date, options) {
+export function formatTime(date, options = {}) {
+
+	if (options.skeleton) return formatDateTimeSkeleton(date, options, { date: false });
 
 	const descriptor = getDateTimeDescriptor();
 	const settings = getDocumentLocaleSettings();
 
-	options = options || {};
 	const timezone = options.timezone || settings.timezone.name;
 	const format = descriptor.formats.timeFormats[options.format]
 		|| options.format || descriptor.formats.timeFormats['short'];
@@ -966,11 +968,12 @@ export function parseTime(input, options) {
 
 }
 
-export function formatDate(date, options) {
+export function formatDate(date, options = {}) {
+
+	if (options.skeleton) return formatDateTimeSkeleton(date, options, { time: false });
 
 	const descriptor = getDateTimeDescriptor();
 
-	options = options || {};
 	options.format = options.format || 'short';
 
 	let format = descriptor.formats.dateFormats[options.format];
@@ -1049,9 +1052,10 @@ export function parseDate(input) {
 
 }
 
-export function formatDateTime(date, options) {
+export function formatDateTime(date, options = {}) {
 
-	options = options || {};
+	if (options.skeleton) return formatDateTimeSkeleton(date, options);
+
 	const format = options.format || 'short';
 
 	switch (format) {

--- a/lib/dateTimeSkeleton.js
+++ b/lib/dateTimeSkeleton.js
@@ -1,0 +1,78 @@
+import { getDocumentLocaleSettings } from './common.js';
+import IntlMessageFormat from 'intl-messageformat';
+import { localeData } from './locale-data/current.js';
+
+const documentLocaleSettings = getDocumentLocaleSettings();
+
+export function formatDateTimeSkeleton(dateTime, options = {}) {
+	const { date = true, time = true, locale } = arguments[2] || {};
+
+	const {
+		timezone: timeZone =
+			options.timeZone
+			|| documentLocaleSettings.timezone.identifier
+			|| undefined,
+		timeZoneName,
+		hourCycle
+	} = options;
+	let {
+		format,
+		skeleton = '',
+	} = options;
+
+	if (!skeleton) {
+		if (date) {
+			if (!format || format === 'short') {
+				skeleton = localeData.dateFormats.short;
+			}
+			else if (format === 'medium') {
+				skeleton = localeData.dateFormats.medium;
+			}
+			else if (format === 'full') {
+				skeleton = localeData.dateFormats.full;
+			}
+		}
+		if (time) {
+			skeleton += localeData.timeFormats.short;
+		}
+
+		if (!skeleton) {
+			console.warn(`"${format}" is not a valid format`);
+			return;
+		}
+
+		format = null;
+	} else {
+		if (!options.forceUnsupportedFormat) {
+			throw 'Use skeletons only if standard supported formats are inarguably insufficient. You must explicitly opt in with the `forceUnsupportedFormat` option.';
+		}
+
+		if (/[HhKkJYuUrM]|j{2,}/.test(skeleton)) {
+			console.warn('Replacing static hour symbols: H/h/K/k/J/jj -> j');
+			skeleton = skeleton.replace(/[HhKkJj]+/g, 'j');
+		}
+		if (!time) skeleton = skeleton.replace(/[HhJjKkmsaZzVvSsBbAOXx]/g, '');
+		if (!date) skeleton = skeleton.replace(/[GyYuUrQqMLwWdDFgEec]/g, '');
+	}
+
+	if (!format && !skeleton) {
+		throw 'No format or skeleton provided. Did you disable `dates` and `times`?';
+	}
+	const msg = `{dateTime, date, ${format || `::${skeleton}`}}`;
+
+	const formatters = {
+		getDateTimeFormat(locale, opts) {
+			return new Intl.DateTimeFormat(locale, {
+				...opts,
+				...{ timeZone, timeZoneName, hourCycle }
+			});
+		}
+	};
+	const dateFormatter = new IntlMessageFormat(msg, locale || documentLocaleSettings.language, null, { formatters });
+	const formatted = dateFormatter.format({ dateTime });
+	return formatted;
+}
+
+const customFormatMap = new Map([
+	['MM/dd/yy', 'en-US', 'MMddyy']
+]);

--- a/lib/dateTimeSkeleton.js
+++ b/lib/dateTimeSkeleton.js
@@ -72,7 +72,3 @@ export function formatDateTimeSkeleton(dateTime, options = {}) {
 	const formatted = dateFormatter.format({ dateTime });
 	return formatted;
 }
-
-const customFormatMap = new Map([
-	['MM/dd/yy', 'en-US', 'MMddyy']
-]);

--- a/test/dateTime.test.js
+++ b/test/dateTime.test.js
@@ -12,6 +12,7 @@ import {
 	parseDate,
 	parseTime
 } from '../lib/dateTime.js';
+import { formatDateTimeSkeleton } from '../lib/dateTimeSkeleton.js';
 import { localeData, registerLocaleDataListener } from '../lib/locale-data/current.js';
 import { expect } from '@brightspace-ui/testing';
 import { getDocumentLocaleSettings } from '../lib/common.js';
@@ -946,6 +947,12 @@ describe('dateTime', () => {
 			});
 		});
 
+		it('should call formatDateTimeSkeleton when `skeleton` option is set', async() => {
+			await setLanguage('de-DE');
+			const result = formatDateTime(new Date(2015, 7, 3, 13, 44), { skeleton: 'EEEELLLLdyjm', forceUnsupportedFormat: true });
+			expect(result).to.equal('Montag, 3. August 2015 um 13:44');
+		})
+
 	});
 
 	describe('formatDateTimeFromTimestamp', () => {
@@ -988,6 +995,67 @@ describe('dateTime', () => {
 				expect(result).to.deep.equal(formatDateTime(test.expectedDate, options));
 			});
 		});
+	});
+
+	describe('formatDateTimeSkeleton', () => {
+		it('should format date and time using skeleton', () => {
+			const date = new Date(2021, 0, 15, 14, 30);
+			const skeleton = 'yLLLLdjms';
+			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
+			expect(result).to.equal('January 15, 2021 at 2:30:00 PM');
+		});
+		it('should throw an error without `forceUnsupportedFormat` option', () => {
+			const date = new Date(2021, 0, 15, 14, 30);
+			const skeleton = 'Mdy';
+			expect(() => formatDateTimeSkeleton(date, { skeleton })).to.throw();
+		});
+		it('should throw an error for invalid skeleton', () => {
+			const date = new Date(2021, 0, 15, 14, 30);
+			const skeleton = 'invalidSkeleton';
+			expect(() => formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true })).to.throw();
+		});
+		it('should format date and time using skeleton with document timezone', () => {
+			documentLocaleSettings.timezone.identifier = 'America/Los_Angeles';
+			const date = new Date(2021, 0, 15, 14, 30);
+			const skeleton = 'yLLLLdjms';
+			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
+			expect(result).to.equal('January 15, 2021 at 11:30:00 AM');
+		});
+		it('should format date and time using skeleton with timezone option', () => {
+			const timeZone = 'America/Los_Angeles';
+			const date = new Date(Date.UTC(2021, 0, 15, 19, 30));
+			const skeleton = 'yLLLLdjms';
+			const result = formatDateTimeSkeleton(date, { skeleton, timeZone, forceUnsupportedFormat: true });
+			expect(result).to.equal('January 15, 2021 at 11:30:00 AM');
+		});
+		it('should ignore time symbols when `time` is false', () => {
+			const date = new Date(2021, 0, 15, 14, 30);
+			const skeleton = 'HhJjKkmsaZzVvSsBbAOXxy';
+			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true }, { time: false });
+			expect(result).to.equal('2021');
+		});
+		it('should ignore date symbols when `date` is false', () => {
+			const date = new Date(2021, 0, 15, 14, 30);
+			const skeleton = 'GyMLdEecHH';
+			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true }, { date: false });
+			expect(result).to.equal('2 PM');
+		})
+		it('should render stand-along months appropriately', async() => {
+			await setLanguage('ca-ES');
+			const date = new Date(2021, 3, 15, 14, 30);
+			let skeleton = 'MMMM';
+			let result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
+			expect(result).to.equal('abril');
+			skeleton = 'MMMMd';
+			result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
+			expect(result).to.equal('15 d’abril');
+		})
+		it('should replace static symbols with dynamic symbols', async() => {
+			const date = new Date(2021, 3, 15, 14, 30);
+			const skeleton = 'HH';
+			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
+			expect(result).to.equal('2 PM');
+		})
 	});
 
 	describe('formatDateFromTimestamp', () => {

--- a/test/dateTime.test.js
+++ b/test/dateTime.test.js
@@ -12,9 +12,9 @@ import {
 	parseDate,
 	parseTime
 } from '../lib/dateTime.js';
-import { formatDateTimeSkeleton } from '../lib/dateTimeSkeleton.js';
 import { localeData, registerLocaleDataListener } from '../lib/locale-data/current.js';
 import { expect } from '@brightspace-ui/testing';
+import { formatDateTimeSkeleton } from '../lib/dateTimeSkeleton.js';
 import { getDocumentLocaleSettings } from '../lib/common.js';
 
 const documentLocaleSettings = getDocumentLocaleSettings();
@@ -951,7 +951,7 @@ describe('dateTime', () => {
 			await setLanguage('de-DE');
 			const result = formatDateTime(new Date(2015, 7, 3, 13, 44), { skeleton: 'EEEELLLLdyjm', forceUnsupportedFormat: true });
 			expect(result).to.equal('Montag, 3. August 2015 um 13:44');
-		})
+		});
 
 	});
 
@@ -1039,7 +1039,7 @@ describe('dateTime', () => {
 			const skeleton = 'GyMLdEecHH';
 			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true }, { date: false });
 			expect(result).to.equal('2 PM');
-		})
+		});
 		it('should render stand-along months appropriately', async() => {
 			await setLanguage('ca-ES');
 			const date = new Date(2021, 3, 15, 14, 30);
@@ -1049,13 +1049,13 @@ describe('dateTime', () => {
 			skeleton = 'MMMMd';
 			result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
 			expect(result).to.equal('15 d’abril');
-		})
+		});
 		it('should replace static symbols with dynamic symbols', async() => {
 			const date = new Date(2021, 3, 15, 14, 30);
 			const skeleton = 'HH';
 			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
 			expect(result).to.equal('2 PM');
-		})
+		});
 	});
 
 	describe('formatDateFromTimestamp', () => {

--- a/test/dateTime.test.js
+++ b/test/dateTime.test.js
@@ -1040,7 +1040,7 @@ describe('dateTime', () => {
 			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true }, { date: false });
 			expect(result).to.equal('2 PM');
 		});
-		it('should render stand-along months appropriately', async() => {
+		it('should render stand-alone months appropriately', async() => {
 			await setLanguage('ca-ES');
 			const date = new Date(2021, 3, 15, 14, 30);
 			let skeleton = 'MMMM';

--- a/test/dateTime.test.js
+++ b/test/dateTime.test.js
@@ -1016,7 +1016,7 @@ describe('dateTime', () => {
 		});
 		it('should format date and time using skeleton with document timezone', () => {
 			documentLocaleSettings.timezone.identifier = 'America/Los_Angeles';
-			const date = new Date(2021, 0, 15, 14, 30);
+			const date = new Date(Date.UTC(2021, 0, 15, 19, 30));
 			const skeleton = 'yLLLLdjms';
 			const result = formatDateTimeSkeleton(date, { skeleton, forceUnsupportedFormat: true });
 			expect(result).to.equal('January 15, 2021 at 11:30:00 AM');


### PR DESCRIPTION
[GAUD-10218](https://desire2learn.atlassian.net/browse/GAUD-10218): Update intl dateTime functions to accept and render from skeleton patterns

For now, we only call `formatDateTimeSkeleton` when the `skeleton` option is explicitly set. Down the road we can start to transition more calls/options to use/convert to skeletons and slowly get rid of the existing custom format handling.

[GAUD-10218]: https://desire2learn.atlassian.net/browse/GAUD-10218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ