### PR TITLE
FIx / improve running build-locale-data scripts locally

### DIFF
--- a/build-locale-data/generate-locale-data.js
+++ b/build-locale-data/generate-locale-data.js
@@ -2,7 +2,7 @@ import * as utils from './utils.js';
 import { env, exit, stderr, stdout } from 'node:process';
 import cldr from 'cldr';
 import config from '../mfv.config.json' with { type: 'json' };
-import { merge } from '../lib/common.js';
+import { merge } from '../lib/common.util.js';
 import { supportedLocalesDetails } from '../lib/locale-data/supported.js';
 
 const overridesPath = new URL('./locale-data-overrides', import.meta.url).pathname;

--- a/lib/common.js
+++ b/lib/common.js
@@ -34,37 +34,6 @@ export function getLanguage() {
 	return langTag;
 }
 
-export function merge(obj1, obj2, keepOriginal = false) {
-	if (obj2 === undefined || obj2 === null || typeof(obj2) !== 'object') {
-		return;
-	}
-	for (const i in obj2) {
-		// eslint-disable-next-line no-prototype-builtins
-		if (obj1.hasOwnProperty(i)) {
-			if (typeof(obj2[i]) === 'object' && typeof(obj1[i]) === 'object') {
-				merge(obj1[i], obj2[i]);
-			} else {
-				if (keepOriginal) obj1[`_original_${i}`] = obj1[i];
-				obj1[i] = obj2[i];
-			}
-		}
-	}
-	return obj1;
-}
-
-export function validateFormatValue(value) {
-	if (value === undefined || value === null) {
-		return 0;
-	}
-	if (typeof value === 'string') {
-		value = parseFloat(value);
-	}
-	if (isNaN(value) || typeof value !== 'number') {
-		throw new RangeError('value is out of range.');
-	}
-	return value;
-}
-
 let documentLocaleSettings = null;
 export function getDocumentLocaleSettings() {
 	if (documentLocaleSettings === null) {

--- a/lib/common.util.js
+++ b/lib/common.util.js
@@ -1,0 +1,30 @@
+export function merge(obj1, obj2, keepOriginal = false) {
+	if (obj2 === undefined || obj2 === null || typeof (obj2) !== 'object') {
+		return;
+	}
+	for (const i in obj2) {
+		// eslint-disable-next-line no-prototype-builtins
+		if (obj1.hasOwnProperty(i)) {
+			if (typeof (obj2[i]) === 'object' && typeof (obj1[i]) === 'object') {
+				merge(obj1[i], obj2[i]);
+			} else {
+				if (keepOriginal) obj1[`_original_${i}`] = obj1[i];
+				obj1[i] = obj2[i];
+			}
+		}
+	}
+	return obj1;
+}
+
+export function validateFormatValue(value) {
+	if (value === undefined || value === null) {
+		return 0;
+	}
+	if (typeof value === 'string') {
+		value = parseFloat(value);
+	}
+	if (isNaN(value) || typeof value !== 'number') {
+		throw new RangeError('value is out of range.');
+	}
+	return value;
+}

--- a/lib/dateTime.js
+++ b/lib/dateTime.js
@@ -1,6 +1,7 @@
-import { getDocumentLocaleSettings, merge } from './common.js';
 import { formatDateTimeSkeleton } from './dateTimeSkeleton.js';
+import { getDocumentLocaleSettings } from './common.js';
 import { localeData } from './locale-data/current.js';
+import { merge } from './common.util.js';
 import { resolveSupportedLocale } from './locale-data/supported.js';
 
 // timezone abbreviations and offsets from https://www.timeanddate.com/time/zones/

--- a/lib/fileSize.js
+++ b/lib/fileSize.js
@@ -1,5 +1,6 @@
-import { getLanguage, validateFormatValue } from './common.js';
 import { formatNumber } from './number.js';
+import { getLanguage } from './common.js';
+import { validateFormatValue } from './common.util.js';
 
 export function getFileSizeDescriptor() {
 

--- a/lib/number.js
+++ b/lib/number.js
@@ -1,9 +1,8 @@
 import {
 	getDocumentLocaleSettings,
-	getLanguage,
-	merge,
-	validateFormatValue
+	getLanguage
 } from './common.js';
+import { merge, validateFormatValue } from './common.util.js';
 
 function formatPositiveInteger(value, descriptor, useGrouping) {
 	value = Math.floor(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@brightspace-ui/testing": "^1",
+        "cldr": "^8.0.0",
         "eslint": "^9",
         "eslint-config-brightspace": "^4",
         "sinon": "^22.0.0"
@@ -2532,6 +2533,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.14",
+      "integrity": "sha512-T4EDRUBVZYRldYApjEJiU0e1stYWaRAX7CuSnKzrpwdZKo53zGV8/pqfzV6FfwNl9YThD2OumQYvqtvjvgG7aQ==",
+      "deprecated": "this version has critical issues, please update to the latest version",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
@@ -3096,6 +3107,18 @@
         "axe-core": "^4.3.3"
       }
     },
+    "node_modules/chainsaw": {
+      "version": "0.0.9",
+      "integrity": "sha512-nG8PYH+/4xB+8zkV4G844EtfvZ5tTiLFoX3dZ4nhF4t3OCKIb9UvaFyNmeZO2zOSmRWzBoTD+napN6hiL+EgcA==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
@@ -3174,6 +3197,23 @@
       },
       "peerDependencies": {
         "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cldr": {
+      "version": "8.0.0",
+      "integrity": "sha512-wRq8XBgmVemoq5jJeSWw8Sq1TdsVx02ZZWvfOAio3OEPjkstGprBHTMC3DxI1tmdd7CjS826lIOsdfgJHMu2lg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.11",
+        "escodegen": "^2.0.0",
+        "esprima": "^4.0.1",
+        "memoizeasync": "^1.1.0",
+        "passerror": "^1.1.1",
+        "pegjs": "^0.10.0",
+        "seq": "^0.3.5",
+        "unicoderegexp": "^0.4.1",
+        "xpath": "^0.0.34"
       }
     },
     "node_modules/clean-css": {
@@ -4073,6 +4113,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/eslint": {
       "version": "9.39.5",
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
@@ -4663,6 +4734,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -5287,6 +5371,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hashish": {
+      "version": "0.0.4",
+      "integrity": "sha512-xyD4XgslstNAs72ENaoFvgMwtv8xhiDtC2AtzCG+8yF7W/Knxxm9BX+e2s25mm+HxMKh0rBmXVOEGF3zNImXvA==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "traverse": ">=0.2.4"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hasown": {
@@ -6843,6 +6939,22 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memoizeasync": {
+      "version": "1.1.0",
+      "integrity": "sha512-HMfzdLqClZo8HMyuM9B6TqnXCNhw82iVWRLqd2cAdXi063v2iJB4mQfWFeKVByN8VUwhmDZ8NMhryBwKrPRf8Q==",
+      "dev": true,
+      "license": "BSD",
+      "dependencies": {
+        "lru-cache": "2.5.0",
+        "passerror": "1.1.1"
+      }
+    },
+    "node_modules/memoizeasync/node_modules/lru-cache": {
+      "version": "2.5.0",
+      "integrity": "sha512-dVmQmXPBlTgFw77hm60ud//l2bCuDKkqC2on1EBoM7s9Urm9IQDrnujwZ93NFnAq0dVZ0HBXTS7PwEG+YE7+EQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
@@ -7692,6 +7804,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/passerror": {
+      "version": "1.1.1",
+      "integrity": "sha512-PwrEQJBkJMxnxG+tdraz95vTstYnCRqiURNbGtg/vZHLgcAODc9hbiD5ZumGUoh3bpw0F0qKLje7Vd2Fd5Lx3g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/path-exists": {
       "version": "3.0.0",
       "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
@@ -7757,6 +7878,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pegjs": {
+      "version": "0.10.0",
+      "integrity": "sha512-qI5+oFNEGi3L5HAxDwN2LA4Gg7irF70Zs25edhjld9QemOgp0CbvMtbFcMvFtEo1OityPrcCzkQFB8JP/hxgow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pegjs": "bin/pegjs"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/picocolors": {
@@ -8385,6 +8518,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/seq": {
+      "version": "0.3.5",
+      "integrity": "sha512-sisY2Ln1fj43KBkRtXkesnRHYNdswIkIibvNe/0UKm2GZxjMbqmccpiatoKr/k2qX5VKiLU8xm+tz/74LAho4g==",
+      "dev": true,
+      "license": "MIT/X11",
+      "dependencies": {
+        "chainsaw": ">=0.0.7 <0.1",
+        "hashish": ">=0.0.2 <0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
@@ -8972,6 +9118,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
+      "dev": true,
+      "license": "MIT/X11",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/true-case-path": {
       "version": "1.0.3",
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
@@ -9227,6 +9382,11 @@
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicoderegexp": {
+      "version": "0.4.1",
+      "integrity": "sha512-ydh8D5mdd2ldTS25GtZJEgLciuF0Qf2n3rwPhonELk3HioX201ClYGvZMc1bCmx6nblZiADQwbMWekeIqs51qw==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -9551,6 +9711,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xpath": {
+      "version": "0.0.34",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "start": "web-dev-server --node-resolve --watch --open /demo/",
     "test:unit": "d2l-test-runner",
-    "test": "npm run lint && npm run test:unit"
+    "test": "npm run lint && npm run test:unit",
+    "build-locale-data": "node ./build-locale-data/build-files.js"
   },
   "files": [
     "/lang",
@@ -41,6 +42,7 @@
   "homepage": "https://github.com/BrightspaceUI/intl",
   "devDependencies": {
     "@brightspace-ui/testing": "^1",
+    "cldr": "^8.0.0",
     "eslint": "^9",
     "eslint-config-brightspace": "^4",
     "sinon": "^22.0.0"


### PR DESCRIPTION
Adding support for new locales involve running scripts ``node /build-locale-data/build-files.js`` 

But that fails because it is missing ``cldr`` dependency + node not having the document DOM API.

I am not sure how @bearfriend typically runs this script so I might have misunderstood. The script is running file locally now, but it generates a lot of locale-data changes?

PS: I am associating this with the vulcan card to add Gaelic support, but this might be more appropriate under a Gaudi card re: improvements in this area? 

https://desire2learn.atlassian.net/browse/VUL-1398