### PR TITLE
Add Gaelic (Irish) support

### DIFF
--- a/lib/locale-data/locales/ga.js
+++ b/lib/locale-data/locales/ga.js
@@ -1,0 +1,391 @@
+export default {
+	languageDisplayName: "Gaeilge",
+	localeDisplayName: "Gaeilge",
+	sourceLocale: "ga",
+	localeCode: "ga",
+	likelySubtag: "ga-Latn-IE",
+	layout: {
+		orientation: {
+			characterOrder: "left-to-right",
+			lineOrder: "top-to-bottom"
+		}
+	},
+	pluralClass: {
+		cardinal: [
+			"one",
+			"two",
+			"few",
+			"many",
+			"other"
+		],
+		ordinal: [
+			"one",
+			"other"
+		]
+	},
+	localeDisplayPattern: {
+		localePattern: "{0} ({1})",
+		localeSeparator: "{0}, {1}",
+		localeKeyTypePattern: "{0}: {1}"
+	},
+	dateFormats: {
+		full: "EEEE d MMMM y",
+		long: "d MMMM y",
+		medium: "d MMM y",
+		short: "d/M/yy"
+	},
+	dateFormatItems: {
+		Ed: "E d",
+		Ehm: "E h:mm a",
+		Ehms: "E h:mm:ss a",
+		Gy: "y G",
+		GyM: "M/y G",
+		GyMd: "dd/MM/y GGGGG",
+		GyMEd: "E, d/M/y G",
+		GyMMM: "MMM y G",
+		GyMMMd: "d MMM y G",
+		GyMMMEd: "E d MMM y G",
+		hm: "h:mm a",
+		hms: "h:mm:ss a",
+		hmsv: "h:mm:ss a v",
+		hmv: "h:mm a v",
+		M: "LL",
+		Md: "dd/MM",
+		MEd: "E dd/MM",
+		MMMd: "d MMM",
+		MMMEd: "E d MMM",
+		MMMMd: "d MMMM",
+		MMMMW: "MMMM: 'seachtain' W",
+		yM: "MM/y",
+		yMd: "dd/MM/y",
+		yMEd: "E dd/MM/y",
+		yMMM: "MMM y",
+		yMMMd: "d MMM y",
+		yMMMEd: "E d MMM y",
+		yMMMM: "MMMM y",
+		yQQQ: "QQQ y",
+		yQQQQ: "QQQQ y",
+		yw: "'seachtain' w 'in' Y",
+		Bh: "h B",
+		Bhm: "h:mm B",
+		Bhms: "h:mm:ss B",
+		d: "d",
+		E: "ccc",
+		EBh: "E h B",
+		EBhm: "E h:mm B",
+		EBhms: "E h:mm:ss B",
+		Eh: "E h a",
+		EHm: "E HH:mm",
+		EHms: "E HH:mm:ss",
+		h: "h a",
+		H: "HH",
+		Hm: "HH:mm",
+		Hms: "HH:mm:ss",
+		Hmsv: "HH:mm:ss v",
+		Hmv: "HH:mm v",
+		hv: "h a v",
+		Hv: "HH'h' v",
+		MMM: "LLL",
+		ms: "mm:ss",
+		y: "y"
+	},
+	timeFormats: {
+		full: "HH:mm:ss zzzz",
+		long: "HH:mm:ss z",
+		medium: "HH:mm:ss",
+		short: "HH:mm"
+	},
+	dayPeriods: {
+		format: {
+			abbreviated: {
+				am: "r.n.",
+				pm: "i.n."
+			},
+			narrow: {
+				am: "r.n.",
+				pm: "i.n."
+			},
+			wide: {
+				am: "r.n.",
+				pm: "i.n."
+			}
+		},
+		standAlone: {
+			abbreviated: {
+				am: "r.n.",
+				pm: "i.n."
+			},
+			narrow: {
+				am: "r.n.",
+				pm: "i.n."
+			},
+			wide: {
+				am: "r.n.",
+				pm: "i.n."
+			}
+		}
+	},
+	dayNames: {
+		format: {
+			abbreviated: [
+				"Domh",
+				"Luan",
+				"Máirt",
+				"Céad",
+				"Déar",
+				"Aoine",
+				"Sath"
+			],
+			narrow: [
+				"D",
+				"L",
+				"M",
+				"C",
+				"D",
+				"A",
+				"S"
+			],
+			wide: [
+				"Dé Domhnaigh",
+				"Dé Luain",
+				"Dé Máirt",
+				"Dé Céadaoin",
+				"Déardaoin",
+				"Dé hAoine",
+				"Dé Sathairn"
+			],
+			short: [
+				"Do",
+				"Lu",
+				"Má",
+				"Cé",
+				"Dé",
+				"Ao",
+				"Sa"
+			]
+		},
+		standAlone: {
+			abbreviated: [
+				"Domh",
+				"Luan",
+				"Máirt",
+				"Céad",
+				"Déar",
+				"Aoine",
+				"Sath"
+			],
+			narrow: [
+				"D",
+				"L",
+				"M",
+				"C",
+				"D",
+				"A",
+				"S"
+			],
+			wide: [
+				"Dé Domhnaigh",
+				"Dé Luain",
+				"Dé Máirt",
+				"Dé Céadaoin",
+				"Déardaoin",
+				"Dé hAoine",
+				"Dé Sathairn"
+			],
+			short: [
+				"Do",
+				"Lu",
+				"Má",
+				"Cé",
+				"Dé",
+				"Ao",
+				"Sa"
+			]
+		}
+	},
+	weekData: {
+		firstDay: 1,
+		weekendStart: 6,
+		weekendEnd: 0
+	},
+	months: {
+		format: {
+			abbreviated: [
+				"Ean",
+				"Feabh",
+				"Márta",
+				"Aib",
+				"Beal",
+				"Meith",
+				"Iúil",
+				"Lún",
+				"MFómh",
+				"DFómh",
+				"Samh",
+				"Noll"
+			],
+			narrow: [
+				"E",
+				"F",
+				"M",
+				"A",
+				"B",
+				"M",
+				"I",
+				"L",
+				"M",
+				"D",
+				"S",
+				"N"
+			],
+			wide: [
+				"Eanáir",
+				"Feabhra",
+				"Márta",
+				"Aibreán",
+				"Bealtaine",
+				"Meitheamh",
+				"Iúil",
+				"Lúnasa",
+				"Meán Fómhair",
+				"Deireadh Fómhair",
+				"Samhain",
+				"Nollaig"
+			]
+		},
+		standAlone: {
+			abbreviated: [
+				"Ean",
+				"Feabh",
+				"Márta",
+				"Aib",
+				"Beal",
+				"Meith",
+				"Iúil",
+				"Lún",
+				"MFómh",
+				"DFómh",
+				"Samh",
+				"Noll"
+			],
+			narrow: [
+				"E",
+				"F",
+				"M",
+				"A",
+				"B",
+				"M",
+				"I",
+				"L",
+				"M",
+				"D",
+				"S",
+				"N"
+			],
+			wide: [
+				"Eanáir",
+				"Feabhra",
+				"Márta",
+				"Aibreán",
+				"Bealtaine",
+				"Meitheamh",
+				"Iúil",
+				"Lúnasa",
+				"Meán Fómhair",
+				"Deireadh Fómhair",
+				"Samhain",
+				"Nollaig"
+			]
+		},
+		transforms: {
+			titleCase: {}
+		}
+	},
+	numberingSystemId: "latn",
+	numberingSystem: {
+		type: "numeric",
+		digits: [
+			"0",
+			"1",
+			"2",
+			"3",
+			"4",
+			"5",
+			"6",
+			"7",
+			"8",
+			"9"
+		]
+	},
+	numberSymbols: {
+		latn: {
+			nan: "Nuimh",
+			decimal: ".",
+			group: ",",
+			list: ";",
+			percentSign: "%",
+			plusSign: "+",
+			minusSign: "-",
+			approximatelySign: "~",
+			exponential: "E",
+			superscriptingExponent: "×",
+			perMille: "‰",
+			infinity: "∞",
+			timeSeparator: ":"
+		},
+		default: {
+			nan: "Nuimh",
+			decimal: ".",
+			group: ",",
+			list: ";",
+			percentSign: "%",
+			plusSign: "+",
+			minusSign: "-",
+			approximatelySign: "~",
+			exponential: "E",
+			superscriptingExponent: "×",
+			perMille: "‰",
+			infinity: "∞",
+			timeSeparator: ":"
+		}
+	},
+	delimiters: {
+		quotationStart: "“",
+		quotationEnd: "”",
+		alternateQuotationStart: "‘",
+		alternateQuotationEnd: "’",
+		apostrophe: "’"
+	},
+	listPatterns: {
+		default: {
+			2: "{0} agus {1}",
+			end: "{0} agus {1}",
+			start: "{0}, {1}",
+			middle: "{0}, {1}"
+		},
+		or: {
+			2: "{0} nó {1}",
+			end: "{0} nó {1}",
+			start: "{0}, {1}",
+			middle: "{0}, {1}"
+		},
+		standardNarrow: {
+			2: "{0}, {1}",
+			end: "{0}, {1}"
+		},
+		unit: {
+			2: "{0} agus {1}",
+			end: "{0} agus {1}"
+		},
+		unitNarrow: {
+			2: "{0} {1}",
+			start: "{0} {1}",
+			middle: "{0} {1}",
+			end: "{0} {1}"
+		},
+		unitShort: {
+			2: "{0}, {1}",
+			end: "{0}, {1}"
+		}
+	}
+};

--- a/lib/locale-data/supported.js
+++ b/lib/locale-data/supported.js
@@ -1,6 +1,6 @@
 export const defaultLocale = 'en';
-export const supportedBaseLocales = ['ar', 'ca', 'cy', 'da', 'de', 'en', 'es', 'fr', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'th', 'tr', 'vi', 'zh', 'ru', 'pl', 'ur'];
-export const supportedLangpacks = ['ar', 'ca', 'cy', 'da', 'de', 'en-gb', 'en', 'es-es', 'es', 'fr-fr', 'fr-on', 'fr', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'th', 'tr', 'vi', 'zh-cn', 'zh-tw', 'ru', 'pl', 'ur'];
+export const supportedBaseLocales = ['ar', 'ca', 'cy', 'da', 'de', 'en', 'es', 'fr', 'ga', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'th', 'tr', 'vi', 'zh', 'ru', 'pl', 'ur'];
+export const supportedLangpacks = ['ar', 'ca', 'cy', 'da', 'de', 'en-gb', 'en', 'es-es', 'es', 'fr-fr', 'fr-on', 'fr', 'ga', 'haw', 'hi', 'ja', 'ko', 'mi', 'nl', 'pt', 'sv', 'th', 'tr', 'vi', 'zh-cn', 'zh-tw', 'ru', 'pl', 'ur'];
 export const supportedLocalesDetails = [
 	{ id: 16, code: 'ar-sa', source: 'ar', pack: 'ar', dir: 'rtl', name: 'العربية' },
 	{ id: 38, code: 'ca-es', source: 'ca', pack: 'ca', dir: 'ltr', name: 'Català (Espanya)' },
@@ -31,6 +31,7 @@ export const supportedLocalesDetails = [
 	{ id: 39, code: 'ru', source: 'ru', pack: 'ru', dir: 'ltr', name: 'русский' },
 	{ id: 40, code: 'pl', source: 'pl', pack: 'pl', dir: 'ltr', name: 'polski' },
 	{ id: 41, code: 'ur', source: 'ur', pack: 'ur', dir: 'rtl', name: 'اردو' },
+	{ id: 42, code: 'ga', source: 'ga', pack: 'ga', dir: 'ltr', name: 'Gaeilge' },
 ];
 // end generated locale data
 


### PR DESCRIPTION
This is re-opening #408 as a standalone PR

---

I added a row to lib/locale-data/support.js like:

```js
{ id: 42, code: 'ga', source: 'ga', pack: 'ga', dir: 'ltr', name: 'Gaeilge (Éire)' },
```
based on https://www.localeplanet.com/icu/ga/index.html

then ran ``/build-locale-data/build-files.js``

which in turn changed the row to what it is now + generated the ``lib/locale-data/locales/ga.js`` as well as a whole lotta other changes which I didn't include.

It's highly likely I am using this script wrong locally

https://desire2learn.atlassian.net/browse/VUL-1398